### PR TITLE
Set Job statuses, improve DB connection handling

### DIFF
--- a/goodtablesio/helpers/create.py
+++ b/goodtablesio/helpers/create.py
@@ -44,7 +44,8 @@ def create_job(validation_conf, job_id=None):
 def insert_job_row(job_id):
     row = {
         'job_id': job_id,
-        'created': datetime.datetime.utcnow()
+        'created': datetime.datetime.utcnow(),
+        'status': 'created'
     }
     services.database['jobs'].insert(row,
                                      types={'created': DateTime},

--- a/goodtablesio/helpers/create.py
+++ b/goodtablesio/helpers/create.py
@@ -36,7 +36,7 @@ def create_job(validation_conf, job_id=None):
     insert_job_row(job_id)
 
     # Create celery task
-    tasks.validate.apply_async((validation_conf,), {'job_id': job_id})
+    tasks.validate.apply_async((validation_conf, job_id))
 
     return job_id
 

--- a/goodtablesio/helpers/retrieve.py
+++ b/goodtablesio/helpers/retrieve.py
@@ -13,21 +13,18 @@ def get_job(job_id):
         dict: job result if job was found, None otherwise
 
     """
-    result = services.database['jobs'].find_one(job_id=job_id)
+    job = services.database['jobs'].find_one(job_id=job_id)
 
-    if not result:
+    if not job:
         return None
-    # TODO: we need to store the status in the DB as we can no longer rely on
-    # the job id being the same one used by a celery task
-    status = 'Not Implemented'
 
     # TODO: this should not be needed after #33
-    if 'report' not in result:
-        result['report'] = None
-    if 'finished' not in result:
-        result['finished'] = None
+    if 'report' not in job:
+        job['report'] = None
+    if 'finished' not in job:
+        job['finished'] = None
 
-    return {'status': status, 'result': result}
+    return job
 
 
 def get_job_ids():

--- a/goodtablesio/models.py
+++ b/goodtablesio/models.py
@@ -5,12 +5,14 @@
 class Job():
 
     job_id = None
+    status = 'created'
     created = None
     finished = None
     report = None
 
     def __init__(self, *args, **kwargs):
         self.job_id = kwargs.get('job_id')
+        self.status = kwargs.get('status', 'created')
         self.created = kwargs.get('created')
         self.finished = kwargs.get('finished')
         self.report = kwargs.get('report')

--- a/goodtablesio/plugins/github/blueprint.py
+++ b/goodtablesio/plugins/github/blueprint.py
@@ -30,6 +30,6 @@ def create_job():
 
     get_validation_conf.apply_async(
         (payload['repository']['clone_url'], job_id),
-        link=tasks.validate.s(job_id=job_id))
+        link=tasks.validate.s(job_id))
 
     return job_id

--- a/goodtablesio/plugins/github/tasks.py
+++ b/goodtablesio/plugins/github/tasks.py
@@ -4,9 +4,7 @@ import subprocess
 import tempfile
 import logging
 
-import dataset
-
-from goodtablesio import helpers, services, config
+from goodtablesio import helpers
 from goodtablesio.tasks import app as celery_app
 
 
@@ -18,11 +16,11 @@ CLONE_DIR = '/tmp'
 
 @celery_app.task(name='goodtablesio.github.get_validation_conf')
 def get_validation_conf(clone_url, job_id):
+    # We need to import the DB connection at this point, as it has been
+    # initialized when the worker started
+    from goodtablesio.tasks import tasks_db
 
-    # TODO: reuse connections
-    database = dataset.connect(config.DATABASE_URL)
-
-    database['jobs'].update({'job_id': job_id, 'status': 'running'},
+    tasks_db['jobs'].update({'job_id': job_id, 'status': 'running'},
                             ['job_id'])
 
     clone_dir = _clone_repo(job_id, clone_url)

--- a/goodtablesio/plugins/github/tasks.py
+++ b/goodtablesio/plugins/github/tasks.py
@@ -4,7 +4,9 @@ import subprocess
 import tempfile
 import logging
 
-from goodtablesio import helpers
+import dataset
+
+from goodtablesio import helpers, services, config
 from goodtablesio.tasks import app as celery_app
 
 
@@ -16,6 +18,12 @@ CLONE_DIR = '/tmp'
 
 @celery_app.task(name='goodtablesio.github.get_validation_conf')
 def get_validation_conf(clone_url, job_id):
+
+    # TODO: reuse connections
+    database = dataset.connect(config.DATABASE_URL)
+
+    database['jobs'].update({'job_id': job_id, 'status': 'running'},
+                            ['job_id'])
 
     clone_dir = _clone_repo(job_id, clone_url)
     job_conf = _get_job_conf(clone_url)

--- a/goodtablesio/tasks.py
+++ b/goodtablesio/tasks.py
@@ -23,7 +23,7 @@ app.autodiscover_tasks(['goodtablesio.plugins.github'])
 
 
 @app.task(name='goodtablesio.tasks.validate')
-def validate(validation_conf, job_id=None):
+def validate(validation_conf, job_id):
     """Main validation task.
 
     Args:
@@ -40,7 +40,7 @@ def validate(validation_conf, job_id=None):
     # Save report
     database = dataset.connect(config.DATABASE_URL)
     row = {
-        'job_id': job_id or validate.request.id,
+        'job_id': job_id,
         'report': report,
         'finished': datetime.datetime.utcnow()
     }

--- a/goodtablesio/templates/job.html
+++ b/goodtablesio/templates/job.html
@@ -4,8 +4,8 @@
 <div class="container">
 
   {% set color = 'black' %}
-  {% if job.result.finished %}
-    {% if job.result.report.valid %}
+  {% if job.finished %}
+    {% if job.report.valid %}
     {% set color = 'green' %}
     {% else %}
     {% set color = 'red' %}
@@ -29,24 +29,24 @@
     </thead>
     <thead>
       <tr>
-        <td>{{ job.result.job_id }}</td>
+        <td>{{ job.job_id }}</td>
         <td>{{ job.status }}</td>
-        <td>{{ job.result.report.valid }}</td>
-        <td>{{ job.result.report['error-count'] }}</td>
-        <td>{{ job.result.report['table-count'] }}</td>
-        <td>{{ job.result.report.time }}</td>
+        <td>{{ job.report.valid }}</td>
+        <td>{{ job.report['error-count'] }}</td>
+        <td>{{ job.report['table-count'] }}</td>
+        <td>{{ job.report.time }}</td>
       </tr>
     </thead>
   </table>
 
-  {% if job.result.finished %}
+  {% if job.finished %}
   <h2>Files</h2>
   {% endif %}
 
-  {% for table in job.result.report.tables %}
+  {% for table in job.report.tables %}
 
     {% set color = 'yellow' %}
-    {% if job.result.report.tables[loop.index0].valid %}
+    {% if job.report.tables[loop.index0].valid %}
     {% set color = 'green' %}
     {% else %}
     {% set color = 'red' %}

--- a/goodtablesio/tests/blueprints/test_api.py
+++ b/goodtablesio/tests/blueprints/test_api.py
@@ -52,9 +52,9 @@ def test_api_get_job(client):
 
     # TODO: Update after #19
 
-    assert 'result' in data
-    assert data['result']['job_id'] == job.job_id
-    assert 'created' in data['result']
+    assert 'report' in data
+    assert data['job_id'] == job.job_id
+    assert 'created' in data
     assert 'status' in data
 
 

--- a/goodtablesio/tests/factories.py
+++ b/goodtablesio/tests/factories.py
@@ -19,6 +19,7 @@ class Job(factory.Factory):
     job_id = factory.Sequence(lambda n: str(uuid.uuid4()))
 
     created = factory.LazyAttribute(lambda o: datetime.datetime.utcnow())
+    status = 'created'
     finished = None
     report = None
 
@@ -26,7 +27,7 @@ class Job(factory.Factory):
     def _create(cls, model_class, *args, **kwargs):
 
         row = {}
-        for field in ('job_id', 'created', 'finished', 'report'):
+        for field in ('job_id', 'created', 'finished', 'report', 'status'):
             row[field] = kwargs.get(field)
 
         services.database['jobs'].insert(row,

--- a/goodtablesio/tests/test_tasks.py
+++ b/goodtablesio/tests/test_tasks.py
@@ -17,6 +17,9 @@ def test_tasks_validate(_inspect):
     mock_report = {'valid': True, 'errors': []}
     _inspect.return_value = mock_report
 
+    # Needed to initialize the DB connection
+    tasks.init_worker()
+
     validation_conf = {'files': ['file1', 'file2'], 'settings': {}}
     tasks.validate(validation_conf, job_id=job.job_id)
 


### PR DESCRIPTION
Fixes #35 

As discussed, jobs are always created with a status of `created`. Plugins or the validation task will set it to `running` when the job starts. After goodtables runs it will be set to `success` or `failure` depending on
the report.

TODO: set to `error` on exceptions

Also rather than creating a DB connection on each task set one per worker and reuse it. This means that tasks should always use `goodtablesio.tasks.tasks_db` rather than `goodtbalesio.services.database`.