### PR TITLE
 Fix exception when there are no files to validate

### DIFF
--- a/goodtablesio/tasks/validate.py
+++ b/goodtablesio/tasks/validate.py
@@ -29,18 +29,28 @@ def validate(validation_conf, job_id):
         }
         models.job.update(params)
 
-    # Get report
-    settings = validation_conf.get('settings', {})
-    inspector = Inspector(**settings)
-    report = inspector.inspect(validation_conf['files'], preset='tables')
+    # Safety checks
+    if not validation_conf.get('files'):
+        params = {
+            'id': job_id,
+            'finished': datetime.datetime.utcnow(),
+            'status': 'error',
+            'error': {'message': 'No files to validate'}
+        }
 
-    # Save report
-    params = {
-        'id': job_id,
-        'report': report,
-        'finished': datetime.datetime.utcnow(),
-        'status': 'success' if report['valid'] else 'failure'
-    }
+    else:
+        # Get report
+        settings = validation_conf.get('settings', {})
+        inspector = Inspector(**settings)
+        report = inspector.inspect(validation_conf['files'], preset='tables')
+
+        # Save report
+        params = {
+            'id': job_id,
+            'report': report,
+            'finished': datetime.datetime.utcnow(),
+            'status': 'success' if report['valid'] else 'failure'
+        }
 
     models.job.update(params)
 

--- a/goodtablesio/tests/tasks/test_validate.py
+++ b/goodtablesio/tests/tasks/test_validate.py
@@ -31,3 +31,21 @@ def test_validate(_inspect):
     assert updated_job['id'] == job.id
     assert updated_job['report'] == mock_report
     assert isinstance(updated_job['finished'], datetime.datetime)
+
+
+def test_validate_no_files():
+
+    # We need to save it on the DB so the session used by the tasks can find it
+    job = factories.Job(_save_in_db=True)
+
+    validation_conf = {'files': [], 'settings': {}}
+    validate(validation_conf, job_id=job.id)
+
+    jobs = models.job.get_all()
+
+    assert len(jobs) == 1
+
+    updated_job = jobs[0]
+    assert updated_job['id'] == job.id
+    assert updated_job['error'] == {'message': 'No files to validate'}
+    assert isinstance(updated_job['finished'], datetime.datetime)


### PR DESCRIPTION
Passing a validation conf with no `files` causes the following exception (I guess that goodtables-py should handle it nicer):

```traceback
 File "/home/adria/dev/pyenvs/gt/src/goodtables.io/goodtablesio/tasks/validate.py", line 35, in validate
    report = inspector.inspect(validation_conf['files'], preset='tables')
  File "/home/adria/dev/pyenvs/gt/lib/python3.5/site-packages/goodtables/inspector.py", line 98, in inspect
    pool = ThreadPool(processes=len(tables))
  File "/usr/lib/python3.5/multiprocessing/pool.py", line 749, in __init__
    Pool.__init__(self, processes, initializer, initargs)
  File "/usr/lib/python3.5/multiprocessing/pool.py", line 161, in __init__
    raise ValueError("Number of processes must be at least 1")
ValueError: Number of processes must be at least 1
```

This happens eg if you activate a github repo with no tabular data. 

 This fix is the most straight-forward, checking at the `validate` task level and storing the job with a status of error. But eventually we might want to consider if plugins are responsible to stop the validation process (chain) at their level. This seems to be non-trivial with celery sadly  (http://stackoverflow.com/questions/17461374/celery-stop-execution-of-a-chain) but we should consider it if chains start becoming more complex.

We might also need to consider whether to cancel or inactivate sources if they keep failing forever (after X failures)

@roll is there any existing convention on how the `error` JSON field should be stored? Right now I'm just doing `{"message": "xxxx"}`. 