### PR TITLE
Use users OAuth token when interacting with the API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ TEST_DATABASE_URL=postgres://<user>:<pass>@localhost:5432/goodtables_test
 BROKER_URL=redis://localhost:6379/10
 RESULT_BACKEND=redis://localhost:6379/11
 FLASK_SECRET_KEY=change_me
+GTIO_SECRET_KEY=change_me
 GITHUB_API_TOKEN=change_me
 GITHUB_HOOK_SECRET=change_me
 GITHUB_CLIENT_ID=change_me

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - BROKER_URL=redis://localhost:6379/10
     - RESULT_BACKEND=redis://localhost:6379/11
     - FLASK_SECRET_KEY=test-key
-    - GTIO_SECRET_KEY=test-key
+    - "GTIO_SECRET_KEY=g2PKWio2rEmNiM1X8mpgCt40wunLJti0SMOT-MfIYjU="
     - GITHUB_HOOK_SECRET=test-github-hook-secret
     - GITHUB_CLIENT_ID=test-github-client-id
     - GITHUB_CLIENT_SECRET=test-github-client-secret

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - BROKER_URL=redis://localhost:6379/10
     - RESULT_BACKEND=redis://localhost:6379/11
     - FLASK_SECRET_KEY=test-key
+    - GTIO_SECRET_KEY=test-key
     - GITHUB_HOOK_SECRET=test-github-hook-secret
     - GITHUB_CLIENT_ID=test-github-client-id
     - GITHUB_CLIENT_SECRET=test-github-client-secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache --virtual build-dependencies \
     libjpeg-turbo-dev \
     libxml2-dev \
     libxslt-dev \
+    libffi-dev \
  && apk add --no-cache --update \
     libstdc++ \
     python3 \

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ $ editor .env # edit your vars
 
 ```
 
+*Note*: `GTIO_SECRET_KEY` must be a 32 bit URL-safe base64 string. You can obtain it by running the followig:
+
+```python
+import base64
+
+base64.urlsafe_b64encode(os.urandom(32))
+```
+
+
 ### Migrations
 
 ```bash

--- a/goodtablesio/auth.py
+++ b/goodtablesio/auth.py
@@ -1,6 +1,5 @@
-from flask import session
 from flask_oauthlib.client import OAuth
-from flask_login import LoginManager
+from flask_login import LoginManager, current_user
 
 from goodtablesio import settings, models
 
@@ -27,7 +26,9 @@ github_auth = oauth.remote_app(
 
 @github_auth.tokengetter
 def get_github_oauth_token():
-    return session.get('auth_github_token')
+    if current_user.is_authenticated:
+        return current_user.github_oauth_token
+    return None
 
 
 @login_manager.user_loader

--- a/goodtablesio/auth.py
+++ b/goodtablesio/auth.py
@@ -2,6 +2,8 @@ from flask_oauthlib.client import OAuth
 from flask_login import LoginManager, current_user
 
 from goodtablesio import settings, models
+from goodtablesio.services import database
+from goodtablesio.models.user import User
 
 GITHUB_OAUTH_SCOPES = ['user', 'repo', 'admin:repo_hook']
 
@@ -33,4 +35,4 @@ def get_github_oauth_token():
 
 @login_manager.user_loader
 def load_user(user_id):
-    return models.user.get(user_id, as_dict=False)
+    return database['session'].query(User).filter_by(id=user_id).one_or_none()

--- a/goodtablesio/auth.py
+++ b/goodtablesio/auth.py
@@ -1,7 +1,7 @@
 from flask_oauthlib.client import OAuth
 from flask_login import LoginManager, current_user
 
-from goodtablesio import settings, models
+from goodtablesio import settings
 from goodtablesio.services import database
 from goodtablesio.models.user import User
 

--- a/goodtablesio/blueprints/user.py
+++ b/goodtablesio/blueprints/user.py
@@ -14,7 +14,6 @@ from goodtablesio.services import database
 from goodtablesio.models.user import User
 from goodtablesio.auth import github_auth
 
-
 log = logging.getLogger(__name__)
 
 user = Blueprint('user', __name__, url_prefix='/user')
@@ -110,7 +109,7 @@ def authorized(provider):
 
         # Update these values
         user.provider_ids.update({provider:  provider_id})
-        user.conf.update({'github_oauth_token': response['access_token']})
+        user.github_oauth_token = response['access_token']
 
         database['session'].add(user)
         database['session'].commit()

--- a/goodtablesio/crypto.py
+++ b/goodtablesio/crypto.py
@@ -1,11 +1,20 @@
+import binascii
 from cryptography.fernet import Fernet
 
 from goodtablesio import settings
 
 
+def _get_crypto_instance(key):
+    try:
+        return Fernet(key)
+    except binascii.Error:
+        raise ValueError('Wrong secret key provided, it must be a 32 bit '
+                         'URL-safe base64 string')
+
+
 def encrypt_string(value, key=settings.GTIO_SECRET_KEY):
 
-    f = Fernet(key)
+    f = _get_crypto_instance(key)
 
     # Ensure we are working with bytes
     if not hasattr(value, 'decode'):
@@ -17,7 +26,7 @@ def encrypt_string(value, key=settings.GTIO_SECRET_KEY):
 
 def decrypt_string(token, key=settings.GTIO_SECRET_KEY):
 
-    f = Fernet(key)
+    f = _get_crypto_instance(key)
 
     # Ensure we are working with bytes
     if not hasattr(token, 'decode'):

--- a/goodtablesio/crypto.py
+++ b/goodtablesio/crypto.py
@@ -1,0 +1,27 @@
+from cryptography.fernet import Fernet
+
+from goodtablesio import settings
+
+
+def encrypt_string(value, key=settings.GTIO_SECRET_KEY):
+
+    f = Fernet(key)
+
+    # Ensure we are working with bytes
+    if not hasattr(value, 'decode'):
+        value = value.encode('utf-8')
+
+    # Return a string
+    return f.encrypt(value).decode('utf-8')
+
+
+def decrypt_string(token, key=settings.GTIO_SECRET_KEY):
+
+    f = Fernet(key)
+
+    # Ensure we are working with bytes
+    if not hasattr(token, 'decode'):
+        token = token.encode('utf-8')
+
+    # Return a string
+    return f.decrypt(token).decode('utf-8')

--- a/goodtablesio/integrations/github/__init__.py
+++ b/goodtablesio/integrations/github/__init__.py
@@ -1,5 +1,6 @@
 # Register models
 import goodtablesio.integrations.github.models.repo
+import goodtablesio.integrations.github.models.user
 
 # Register tasks
 import goodtablesio.integrations.github.tasks.jobconf

--- a/goodtablesio/integrations/github/blueprint.py
+++ b/goodtablesio/integrations/github/blueprint.py
@@ -8,6 +8,7 @@ from flask_login import login_required, current_user
 
 from goodtablesio import models, settings
 from goodtablesio.services import database
+from goodtablesio.models.job import Job
 from goodtablesio.tasks.validate import validate
 from goodtablesio.utils.signature import validate_signature
 from goodtablesio.integrations.github.models.repo import GithubRepo
@@ -15,7 +16,8 @@ from goodtablesio.integrations.github.tasks.jobconf import get_validation_conf
 from goodtablesio.integrations.github.tasks.repos import sync_user_repos
 from goodtablesio.integrations.github.utils.status import set_commit_status
 from goodtablesio.integrations.github.utils.hook import (
-    activate_hook, deactivate_hook, get_owner_repo_sha_from_hook_payload)
+    activate_hook, deactivate_hook, get_owner_repo_sha_from_hook_payload,
+    get_tokens_for_job)
 
 
 log = logging.getLogger(__name__)
@@ -110,14 +112,8 @@ def github_settings():
 @github.route('/sync')
 @login_required
 def sync():
-    user_id = session['user_id']
 
-    token = current_user.github_oauth_token
-    if not token:
-        flash('No valid GitHub token found', 'danger')
-        return redirect(url_for('github.github_settings'))
-
-    result = sync_user_repos.delay(user_id, token)
+    result = sync_user_repos.delay(current_user.id)
     # TODO: store in the database (not session)
     # It's kinda general problem it looks like we need
     # to track syncing tasks in the database (github, s3, etc)
@@ -202,8 +198,7 @@ def create_job():
 
     # Save job to database
     job_id = str(uuid.uuid4())
-
-    models.job.create({
+    params = {
         'id': job_id,
         'integration_name': 'github',
         'source_id': source.id,
@@ -212,7 +207,14 @@ def create_job():
             'repo': repo,
             'sha': sha,
         }
-    })
+    }
+    job = Job(**params)
+    job.source = source
+
+    database['session'].add(job)
+    database['session'].commit()
+
+    tokens = get_tokens_for_job(job)
 
     # Set GitHub status
     set_commit_status(
@@ -220,7 +222,8 @@ def create_job():
         owner=owner,
         repo=repo,
         sha=sha,
-        job_id=job_id)
+        job_id=job_id,
+        tokens=tokens)
 
     # Run validation
     tasks_chain = chain(

--- a/goodtablesio/integrations/github/models/user.py
+++ b/goodtablesio/integrations/github/models/user.py
@@ -1,0 +1,21 @@
+from goodtablesio.models.user import User
+
+
+def get_token(self):
+    return self.conf.get('github_oauth_token')
+
+
+def set_token(self, value):
+    if not self.conf:
+        self.conf = {}
+    self.conf['github_oauth_token'] = value
+
+
+def del_token(self):
+    del self.conf['github_oauth_token']
+
+
+github_oauth_token = property(
+    get_token, set_token, del_token, 'GitHub OAuth Token')
+
+setattr(User, 'github_oauth_token', github_oauth_token)

--- a/goodtablesio/integrations/github/models/user.py
+++ b/goodtablesio/integrations/github/models/user.py
@@ -1,14 +1,26 @@
+import cryptography
+
+from goodtablesio.crypto import encrypt_string, decrypt_string
 from goodtablesio.models.user import User
 
 
 def get_token(self):
-    return self.conf.get('github_oauth_token')
+    token = self.conf.get('github_oauth_token')
+    if token:
+        try:
+            token = decrypt_string(token)
+        except cryptography.fernet.InvalidToken:
+            # This happens if someone sets the github_oauth_token directly
+            # on the conf property (ie it should never happen)
+            token = None
+
+    return token
 
 
 def set_token(self, value):
     if not self.conf:
         self.conf = {}
-    self.conf['github_oauth_token'] = value
+    self.conf['github_oauth_token'] = encrypt_string(value)
 
 
 def del_token(self):

--- a/goodtablesio/integrations/github/tasks/repos.py
+++ b/goodtablesio/integrations/github/tasks/repos.py
@@ -7,10 +7,12 @@ from goodtablesio.integrations.github.utils.repos import iter_repos_by_token
 
 
 @celery_app.task(name='goodtablesio.github.sync_user_repos')
-def sync_user_repos(user_id, token):
+def sync_user_repos(user_id):
     """Sync user repositories.
     """
     user = database['session'].query(User).get(user_id)
+
+    token = user.github_oauth_token
 
     for repo_data in iter_repos_by_token(token):
         repo = database['session'].query(GithubRepo).filter(

--- a/goodtablesio/integrations/github/utils/hook.py
+++ b/goodtablesio/integrations/github/utils/hook.py
@@ -58,3 +58,8 @@ def get_owner_repo_sha_from_hook_payload(payload):
         return None, None, None
 
     return owner, repo, sha
+
+
+def get_tokens_for_job(job):
+    return [user.github_oauth_token
+            for user in job.source.users if user.github_oauth_token]

--- a/goodtablesio/integrations/github/utils/status.py
+++ b/goodtablesio/integrations/github/utils/status.py
@@ -6,17 +6,21 @@ log = logging.getLogger(__name__)
 
 # Module API
 
-def set_commit_status(state, owner, repo, sha, job_id):
+def set_commit_status(state, owner, repo, sha, job_id, tokens):
     """Set commit status on GitHub.
     """
+
+    if not tokens:
+        return False
 
     url = '{base}/repos/{owner}/{repo}/statuses/{sha}'.format(
         base=settings.GITHUB_API_BASE,
         owner=owner, repo=repo, sha=sha,
     )
 
+    # TODO: use other tokens if first fails
     headers = {
-        'Authorization': 'token {0}'.format(settings.GITHUB_API_TOKEN),
+        'Authorization': 'token {0}'.format(tokens[0]),
     }
 
     if state == 'pending':

--- a/goodtablesio/integrations/s3/blueprint.py
+++ b/goodtablesio/integrations/s3/blueprint.py
@@ -73,9 +73,8 @@ def add_bucket():
         # Redirect and flash message
         if success:
 
-            conf = {'access_key_id': access_key_id,
-                    'secret_access_key': secret_access_key}
-            create_bucket(bucket_name, user=current_user, conf=conf)
+            create_bucket(bucket_name, access_key_id, secret_access_key,
+                          user=current_user)
 
             flash('Bucket added', 'success')
         else:
@@ -97,11 +96,8 @@ def remove_bucket(bucket_name):
 
     else:
 
-        access_key_id = source.conf['access_key_id']
-        secret_access_key = source.conf['secret_access_key']
-
         success, message = disable_bucket_on_aws(
-            access_key_id, secret_access_key, bucket_name)
+            source.access_key_id, source.secret_access_key, bucket_name)
 
         # Redirect and flash message
         if success:

--- a/goodtablesio/integrations/s3/models/bucket.py
+++ b/goodtablesio/integrations/s3/models/bucket.py
@@ -1,4 +1,7 @@
+import cryptography
+
 from goodtablesio.models.source import Source
+from goodtablesio.crypto import encrypt_string, decrypt_string
 
 
 class S3Bucket(Source):
@@ -6,3 +9,44 @@ class S3Bucket(Source):
     __mapper_args__ = {
         'polymorphic_identity': 's3'
     }
+
+    def _get_encrypted(self, key):
+        token = self.conf.get(key)
+        if token:
+            try:
+                token = decrypt_string(token)
+            except cryptography.fernet.InvalidToken:
+                # This happens if someone sets the key directly
+                # on the conf property (ie it should never happen)
+                token = None
+
+        return token
+
+    def _set_encrypted(self, key, value):
+        if not self.conf:
+            self.conf = {}
+        self.conf[key] = encrypt_string(value)
+
+    @property
+    def access_key_id(self):
+        return self._get_encrypted('access_key_id')
+
+    @access_key_id.setter
+    def access_key_id(self, value):
+        return self._set_encrypted('access_key_id', value)
+
+    @access_key_id.deleter
+    def access_key_id(self):
+        del self.conf['access_key_id']
+
+    @property
+    def secret_access_key(self):
+        return self._get_encrypted('secret_access_key')
+
+    @secret_access_key.setter
+    def secret_access_key(self, value):
+        return self._set_encrypted('secret_access_key', value)
+
+    @secret_access_key.deleter
+    def secret_access_key(self):
+        del self.conf['secret_access_key']

--- a/goodtablesio/integrations/s3/tasks/jobconf.py
+++ b/goodtablesio/integrations/s3/tasks/jobconf.py
@@ -27,8 +27,8 @@ def get_validation_conf(bucket, job_id):
         'status': 'running'
     })
 
-    access_key_id = job.source.conf['access_key_id']
-    secret_access_key = job.source.conf['secret_access_key']
+    access_key_id = job.source.access_key_id
+    secret_access_key = job.source.secret_access_key
     bucket_name = job.source.name
 
     client = boto3.client(

--- a/goodtablesio/integrations/s3/utils/bucket.py
+++ b/goodtablesio/integrations/s3/utils/bucket.py
@@ -65,7 +65,8 @@ def disable_bucket_on_aws(access_key_id, secret_access_key, bucket_name):
     return True, ''
 
 
-def create_bucket(bucket_name, user=None, conf=None):
+def create_bucket(bucket_name, access_key_id=None, secret_access_key=None,
+                  user=None):
 
     bucket = database['session'].query(S3Bucket).filter(
         S3Bucket.name == bucket_name).one_or_none()
@@ -76,11 +77,13 @@ def create_bucket(bucket_name, user=None, conf=None):
         bucket = S3Bucket(name=bucket_name)
 
     bucket.active = True
+    if access_key_id:
+        bucket.access_key_id = access_key_id
+    if secret_access_key:
+        bucket.secret_access_key = secret_access_key
 
     if user:
         bucket.users.append(user)
-    if conf:
-        bucket.conf = conf
 
     database['session'].add(bucket)
     database['session'].commit()

--- a/goodtablesio/models/job.py
+++ b/goodtablesio/models/job.py
@@ -5,6 +5,7 @@ from sqlalchemy import (
     Column, Unicode, DateTime, update as db_update,  ForeignKey)
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableDict
 
 from goodtablesio import settings
 from goodtablesio.services import database
@@ -26,7 +27,7 @@ class Job(Base, BaseModelMixin):
     error = Column(JSONB)
     integration_name = Column(
         Unicode, ForeignKey('integrations.name'), default='api')
-    conf = Column(JSONB)
+    conf = Column(MutableDict.as_mutable(JSONB))
     source_id = Column(Unicode, ForeignKey('sources.id'))
 
     source = relationship(

--- a/goodtablesio/models/user.py
+++ b/goodtablesio/models/user.py
@@ -1,11 +1,11 @@
 import logging
 import datetime
 
-from sqlalchemy import Column, Unicode, DateTime, Boolean, update as db_update
+from sqlalchemy import Column, Unicode, DateTime, Boolean
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableDict
 from flask_login import UserMixin as UserLoginMixin
 
-from goodtablesio.services import database
 from goodtablesio.models.base import Base, BaseModelMixin, make_uuid
 
 
@@ -22,157 +22,9 @@ class User(Base, BaseModelMixin, UserLoginMixin):
     display_name = Column(Unicode)
     created = Column(DateTime(timezone=True), default=datetime.datetime.utcnow)
     admin = Column(Boolean, nullable=False, default=False)
-    provider_ids = Column(JSONB)
+    provider_ids = Column(MutableDict.as_mutable(JSONB))
     conf = Column(JSONB)
 
     def get_id(self):
         """This method is required by Flask-Login"""
         return self.id
-
-
-def create(params):
-    """
-    Creates a user object in the database.
-
-    Arguments:
-        params (dict): A dictionary with the values for the new user.
-
-    Returns:
-        user (dict): The newly created user as a dict
-    """
-
-    user = User(**params)
-
-    database['session'].add(user)
-    database['session'].commit()
-
-    log.debug('Created user "%s" on the database', user.id)
-    return user.to_dict()
-
-
-def update(params):
-    """
-    Updates a user object in the database.
-
-    Arguments:
-        params (dict): A dictionary with the fields to be updated. It must
-            contain a valid `user_id` key.
-
-    Returns:
-        user (dict): The updated user as a dict
-
-    Raises:
-        ValueError: A `user_id` was not provided in the params dict.
-    """
-
-    user_id = params.get('id')
-    if not user_id:
-        raise ValueError('You must provide a id in the params dict')
-
-    user = database['session'].query(User).get(user_id)
-    if not user:
-        raise ValueError('User not found: %s', user_id)
-
-    user_table = User.__table__
-    u = db_update(user_table).where(
-        user_table.c.id == user_id).values(**params)
-
-    database['session'].execute(u)
-    database['session'].commit()
-
-    log.debug('Updated user "%s" on the database', user_id)
-    return user.to_dict()
-
-
-def get(user_id, as_dict=True):
-    """
-    Get a user object in the database by id and return it as a dict.
-
-    Arguments:
-        user_id (str): The user id.
-        as_dict (bool): Return the user as dict, rather than a model object.
-            Defaults to True.
-
-    Returns:
-        user (dict): A dictionary with the user details, or None if the user
-            was not found.
-    """
-
-    user = database['session'].query(User).get(user_id)
-
-    if not user:
-        return None
-
-    return user.to_dict() if as_dict else user
-
-
-def get_by_email(email):
-    """
-    Get a user object in the database by email and return it as a dict.
-
-    Arguments:
-        email (str): The user email.
-
-    Returns:
-        user (dict): A dictionary with the user details, or None if the user
-            was not found.
-    """
-
-    user = database['session'].query(User).filter_by(email=email).one_or_none()
-
-    if not user:
-        return None
-
-    return user.to_dict()
-
-
-def get_by_provider_id(provider_name, provider_id):
-    """
-    Get a user object in the database by a 3rd party provider id and return it
-        as a dict.
-
-    Arguments:
-        provider_name (str): The 3rd party provider (eg `github`).
-        provider_id (str): The 3rd party provider id.
-
-    Returns:
-        user (dict): A dictionary with the user details, or None if the user
-            was not found.
-    """
-
-    user = database['session'].query(User).filter(
-        User.provider_ids[provider_name].astext == str(provider_id)
-        ).one_or_none()
-
-    if not user:
-        return None
-
-    return user.to_dict()
-
-
-def get_ids():
-    """Get all user ids from the database.
-
-    Returns:
-        user_ids (str[]): A list of user ids, sorted by descending creation
-        date.
-
-    """
-
-    user_ids = database['session'].query(User.id).order_by(User.created.desc()).all()
-    return [j.id for j in user_ids]
-
-
-def find():
-    """Get all users in the database as dict.
-
-    Warning: Use with caution, this should probably only be used in tests
-
-    Returns:
-        users (dict[]): A list of user dicts, sorted by descending creation
-        date.
-
-    """
-
-    users = database['session'].query(User).order_by(User.created.desc()).all()
-    return [j.to_dict() for j in users]

--- a/goodtablesio/models/user.py
+++ b/goodtablesio/models/user.py
@@ -23,7 +23,7 @@ class User(Base, BaseModelMixin, UserLoginMixin):
     created = Column(DateTime(timezone=True), default=datetime.datetime.utcnow)
     admin = Column(Boolean, nullable=False, default=False)
     provider_ids = Column(MutableDict.as_mutable(JSONB))
-    conf = Column(JSONB)
+    conf = Column(MutableDict.as_mutable(JSONB))
 
     def get_id(self):
         """This method is required by Flask-Login"""

--- a/goodtablesio/models/user.py
+++ b/goodtablesio/models/user.py
@@ -23,6 +23,7 @@ class User(Base, BaseModelMixin, UserLoginMixin):
     created = Column(DateTime(timezone=True), default=datetime.datetime.utcnow)
     admin = Column(Boolean, nullable=False, default=False)
     provider_ids = Column(JSONB)
+    conf = Column(JSONB)
 
     def get_id(self):
         """This method is required by Flask-Login"""

--- a/goodtablesio/settings.py
+++ b/goodtablesio/settings.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 # General
 
 BASE_URL = os.environ['BASE_URL']
+GTIO_SECRET_KEY = os.environ['GTIO_SECRET_KEY']
 
 # Flask
 

--- a/goodtablesio/tests/integrations/github/models/test_user.py
+++ b/goodtablesio/tests/integrations/github/models/test_user.py
@@ -8,9 +8,16 @@ pytestmark = pytest.mark.usefixtures('session_cleanup')
 
 def test_github_oauth_token_get():
 
-    user = factories.User(conf={'github_oauth_token': 'xxx'})
+    user = factories.User(github_oauth_token='xxx')
 
     assert user.github_oauth_token == 'xxx'
+
+
+def test_github_oauth_token_get_unencrypted():
+
+    user = factories.User(conf={'github_oauth_token': 'xxx'})
+
+    assert user.github_oauth_token is None
 
 
 def test_github_oauth_token_set():
@@ -19,7 +26,8 @@ def test_github_oauth_token_set():
 
     user.github_oauth_token = 'xxx'
 
-    assert user.conf['github_oauth_token'] == 'xxx'
+    # Encrypted
+    assert user.conf['github_oauth_token'].startswith('gAAA')
 
     database['session'].commit()
     user_db = database['session'].query(User).first()

--- a/goodtablesio/tests/integrations/github/models/test_user.py
+++ b/goodtablesio/tests/integrations/github/models/test_user.py
@@ -1,0 +1,41 @@
+import pytest
+from goodtablesio.tests import factories
+from goodtablesio.services import database
+from goodtablesio.models.user import User
+
+pytestmark = pytest.mark.usefixtures('session_cleanup')
+
+
+def test_github_oauth_token_get():
+
+    user = factories.User(conf={'github_oauth_token': 'xxx'})
+
+    assert user.github_oauth_token == 'xxx'
+
+
+def test_github_oauth_token_set():
+
+    user = factories.User()
+
+    user.github_oauth_token = 'xxx'
+
+    assert user.conf['github_oauth_token'] == 'xxx'
+
+    database['session'].commit()
+    user_db = database['session'].query(User).first()
+
+    assert user_db.github_oauth_token == 'xxx'
+
+
+def test_github_oauth_token_del():
+
+    user = factories.User(github_oauth_token='xxx')
+
+    del user.github_oauth_token
+
+    assert user.github_oauth_token is None
+
+    database['session'].commit()
+    user_db = database['session'].query(User).first()
+
+    assert user_db.github_oauth_token is None

--- a/goodtablesio/tests/integrations/github/tasks/test_jobconf.py
+++ b/goodtablesio/tests/integrations/github/tasks/test_jobconf.py
@@ -1,4 +1,6 @@
 from unittest.mock import patch
+
+from goodtablesio import settings
 from goodtablesio.integrations.github.tasks import jobconf
 
 # Constants
@@ -6,6 +8,7 @@ from goodtablesio.integrations.github.tasks import jobconf
 OWNER = 'frictionlessdata'
 REPO = 'goodtables.io-example'
 SHA = 'd5be243487d9882d7f762e7fa04b36b900164a59'
+TOKENS = [settings.GITHUB_API_TOKEN]
 
 
 # Tests
@@ -18,7 +21,7 @@ def test_get_job_base():
 
 
 def test_get_job_files():
-    actual = jobconf._get_job_files(OWNER, REPO, SHA)
+    actual = jobconf._get_job_files(OWNER, REPO, SHA, TOKENS)
     expect = [
         'README.md',
         'data/invalid.csv',
@@ -31,7 +34,7 @@ def test_get_job_files():
 @patch.object(jobconf, '_get_job_files_tree_api')
 def test_get_job_files_fallback(_get_job_files_tree_api):
     _get_job_files_tree_api.return_value = None
-    actual = jobconf._get_job_files(OWNER, REPO, SHA)
+    actual = jobconf._get_job_files(OWNER, REPO, SHA, TOKENS)
     expect = [
         'README.md',
         'data/invalid.csv',

--- a/goodtablesio/tests/integrations/github/tasks/test_repos.py
+++ b/goodtablesio/tests/integrations/github/tasks/test_repos.py
@@ -7,10 +7,9 @@ pytestmark = pytest.mark.usefixtures('session_cleanup')
 # Tests
 
 def test_sync_user_repos(GitHubForIterRepos):
-    token = 'TOKEN'
-    user = factories.User()
-    sync_user_repos(user.id, token)
-    GitHubForIterRepos.assert_called_with(token=token)
+    user = factories.User(github_oauth_token='my-token')
+    sync_user_repos(user.id)
+    GitHubForIterRepos.assert_called_with(token='my-token')
     assert user.sources[0].conf['github_id'] == 'id1'
     assert user.sources[0].name == 'owner1/repo1'
     assert user.sources[0].active is True

--- a/goodtablesio/tests/integrations/github/test_blueprint.py
+++ b/goodtablesio/tests/integrations/github/test_blueprint.py
@@ -16,7 +16,10 @@ pytestmark = pytest.mark.usefixtures('session_cleanup')
 @patch('goodtablesio.integrations.github.utils.status.set_commit_status')
 def test_create_job(set_commit_status, client, celery_app):
 
-    factories.GithubRepo(name='frictionlessdata/goodtables.io-example')
+    # TODO: refactor to not use actual calls!
+    user = factories.User(github_oauth_token=settings.GITHUB_API_TOKEN)
+    factories.GithubRepo(name='frictionlessdata/goodtables.io-example',
+                         users=[user])
 
     data = json.dumps({
         'repository': {

--- a/goodtablesio/tests/integrations/github/utils/test_status.py
+++ b/goodtablesio/tests/integrations/github/utils/test_status.py
@@ -11,7 +11,10 @@ def test_set_commit_status_success(mock_post):
     mock_response.status_code = 201
     mock_post.return_value = mock_response
 
-    r = set_commit_status('success', 'my-org', 'my-repo', 'abcde', 'my-job-id')
+    tokens = ['my-token']
+
+    r = set_commit_status(
+        'success', 'my-org', 'my-repo', 'abcde', 'my-job-id', tokens)
 
     assert r
 
@@ -20,7 +23,7 @@ def test_set_commit_status_success(mock_post):
     )
 
     expected_headers = {
-        'Authorization': 'token {0}'.format(settings.GITHUB_API_TOKEN),
+        'Authorization': 'token my-token'
     }
 
     expected_data = {
@@ -40,7 +43,10 @@ def test_set_commit_status_failure(mock_post):
     mock_response.status_code = 201
     mock_post.return_value = mock_response
 
-    r = set_commit_status('failure', 'my-org', 'my-repo', 'abcde', 'my-job-id')
+    tokens = ['my-token']
+
+    r = set_commit_status(
+        'failure', 'my-org', 'my-repo', 'abcde', 'my-job-id', tokens)
 
     assert r
 
@@ -49,7 +55,7 @@ def test_set_commit_status_failure(mock_post):
     )
 
     expected_headers = {
-        'Authorization': 'token {0}'.format(settings.GITHUB_API_TOKEN),
+        'Authorization': 'token my-token'
     }
 
     expected_data = {
@@ -69,7 +75,10 @@ def test_set_commit_status_pending(mock_post):
     mock_response.status_code = 201
     mock_post.return_value = mock_response
 
-    r = set_commit_status('pending', 'my-org', 'my-repo', 'abcde', 'my-job-id')
+    tokens = ['my-token']
+
+    r = set_commit_status(
+        'pending', 'my-org', 'my-repo', 'abcde', 'my-job-id', tokens)
 
     assert r
 
@@ -78,7 +87,7 @@ def test_set_commit_status_pending(mock_post):
     )
 
     expected_headers = {
-        'Authorization': 'token {0}'.format(settings.GITHUB_API_TOKEN),
+        'Authorization': 'token my-token'
     }
 
     expected_data = {
@@ -98,7 +107,10 @@ def test_set_commit_status_error(mock_post):
     mock_response.status_code = 201
     mock_post.return_value = mock_response
 
-    r = set_commit_status('error', 'my-org', 'my-repo', 'abcde', 'my-job-id')
+    tokens = ['my-token']
+
+    r = set_commit_status(
+        'error', 'my-org', 'my-repo', 'abcde', 'my-job-id', tokens)
 
     assert r
 
@@ -107,7 +119,7 @@ def test_set_commit_status_error(mock_post):
     )
 
     expected_headers = {
-        'Authorization': 'token {0}'.format(settings.GITHUB_API_TOKEN),
+        'Authorization': 'token my-token'
     }
 
     expected_data = {
@@ -127,7 +139,10 @@ def test_set_commit_status_problem(mock_post):
     mock_response.status_code = 400
     mock_post.return_value = mock_response
 
-    r = set_commit_status('success', 'my-org', 'my-repo', 'abcde', 'my-job-id')
+    tokens = ['my-token']
+
+    r = set_commit_status(
+        'success', 'my-org', 'my-repo', 'abcde', 'my-job-id', tokens)
 
     assert not r
 

--- a/goodtablesio/tests/integrations/s3/models/test_s3bucket.py
+++ b/goodtablesio/tests/integrations/s3/models/test_s3bucket.py
@@ -1,0 +1,92 @@
+import pytest
+from goodtablesio.tests import factories
+from goodtablesio.services import database
+from goodtablesio.integrations.s3.models.bucket import S3Bucket
+
+pytestmark = pytest.mark.usefixtures('session_cleanup')
+
+
+def test_access_key_id_get():
+
+    bucket = factories.S3Bucket(access_key_id='xxx')
+
+    assert bucket.access_key_id == 'xxx'
+
+
+def test_access_key_id_get_unencrypted():
+
+    bucket = factories.S3Bucket(conf={'access_key_id': 'xxx'})
+
+    assert bucket.access_key_id is None
+
+
+def test_access_key_id_set():
+
+    bucket = factories.S3Bucket()
+
+    bucket.access_key_id = 'xxx'
+
+    # Encrypted
+    assert bucket.conf['access_key_id'].startswith('gAAA')
+
+    database['session'].commit()
+    bucket_db = database['session'].query(S3Bucket).first()
+
+    assert bucket_db.access_key_id == 'xxx'
+
+
+def test_access_key_id_del():
+
+    bucket = factories.S3Bucket(access_key_id='xxx')
+
+    del bucket.access_key_id
+
+    assert bucket.access_key_id is None
+
+    database['session'].commit()
+    bucket_db = database['session'].query(S3Bucket).first()
+
+    assert bucket_db.access_key_id is None
+
+
+def test_secret_access_key_get():
+
+    bucket = factories.S3Bucket(secret_access_key='xxx')
+
+    assert bucket.secret_access_key == 'xxx'
+
+
+def test_secret_access_key_get_unencrypted():
+
+    bucket = factories.S3Bucket(conf={'secret_access_key': 'xxx'})
+
+    assert bucket.secret_access_key is None
+
+
+def test_secret_access_key_set():
+
+    bucket = factories.S3Bucket()
+
+    bucket.secret_access_key = 'xxx'
+
+    # Encrypted
+    assert bucket.conf['secret_access_key'].startswith('gAAA')
+
+    database['session'].commit()
+    bucket_db = database['session'].query(S3Bucket).first()
+
+    assert bucket_db.secret_access_key == 'xxx'
+
+
+def test_secret_access_key_del():
+
+    bucket = factories.S3Bucket(secret_access_key='xxx')
+
+    del bucket.secret_access_key
+
+    assert bucket.secret_access_key is None
+
+    database['session'].commit()
+    bucket_db = database['session'].query(S3Bucket).first()
+
+    assert bucket_db.secret_access_key is None

--- a/goodtablesio/tests/integrations/s3/utils/test_bucket.py
+++ b/goodtablesio/tests/integrations/s3/utils/test_bucket.py
@@ -178,10 +178,10 @@ def test_set_up_bucket_on_aws_lambda_add_notification_fails_second_revert_also_f
         b.assert_called_once_with('test_bucket')
 
 
-# def test_disable_bucket_on_aws(mock_s3_client, mock_lambda_client):
-#
-#     args = ('mock_access_key_id', 'mock_secret_access_key', 'test_bucket')
-#     assert disable_bucket_on_aws(*args) == (True, '')
+def test_disable_bucket_on_aws(mock_s3_client, mock_lambda_client):
+
+    args = ('mock_access_key_id', 'mock_secret_access_key', 'test_bucket')
+    assert disable_bucket_on_aws(*args) == (True, '')
 
 
 def test_disable_bucket_on_aws_s3_connection_error(mock_lambda_client):
@@ -332,11 +332,11 @@ def test_inactivate_bucket():
 
 
 @pytest.mark.usefixtures('session_cleanup')
-def test_create_bucket_with_conf():
+def test_create_bucket_with_keys():
 
-    conf = {'a': 'b'}
-
-    create_bucket('test-bucket-2', conf=conf)
+    create_bucket('test-bucket-2',
+                  access_key_id='some-key',
+                  secret_access_key='some-secret')
 
     buckets = database['session'].query(S3Bucket).all()
 
@@ -344,7 +344,12 @@ def test_create_bucket_with_conf():
 
     assert buckets[0].name == 'test-bucket-2'
 
-    assert buckets[0].conf == conf
+    assert buckets[0].access_key_id == 'some-key'
+    assert buckets[0].secret_access_key == 'some-secret'
+
+    # Encrypted
+    assert buckets[0].conf['access_key_id'].startswith('gAA')
+    assert buckets[0].conf['secret_access_key'].startswith('gAA')
 
 
 @pytest.mark.usefixtures('session_cleanup')

--- a/goodtablesio/tests/models/test_job.py
+++ b/goodtablesio/tests/models/test_job.py
@@ -3,6 +3,7 @@ import datetime
 import pytest
 
 from goodtablesio import models
+from goodtablesio.models.job import Job
 from goodtablesio.tests import factories
 from goodtablesio.services import database
 
@@ -270,3 +271,19 @@ def test_get_by_integration_not_found():
     factories.Job()
 
     assert models.job.get_by_integration('not-found') == []
+
+
+def test_json_fields_mutable():
+
+    job = factories.Job(id='my-id', conf={'a': '1'}, _save_in_db=True)
+
+    job.conf.update({'b': '2'})
+
+    database['session'].add(job)
+    database['session'].commit()
+
+    database['session'].remove()
+
+    job = database['session'].query(Job).get('my-id')
+
+    assert job.conf == {'a': '1', 'b': '2'}

--- a/goodtablesio/tests/models/test_user.py
+++ b/goodtablesio/tests/models/test_user.py
@@ -16,6 +16,7 @@ def test_create_user_outputs_dict():
         'email': 'my-email@example.com',
         'admin': True,
         'provider_ids': {'github': '123'},
+        'conf': {'some_token': 'xxx'},
     })
 
     assert user['id'] == 'my-id'
@@ -24,6 +25,7 @@ def test_create_user_outputs_dict():
     assert user['admin'] is True
     assert user['created']
     assert user['provider_ids']['github'] == '123'
+    assert user['conf']['some_token'] == 'xxx'
 
 
 def test_create_user_stored_in_db():

--- a/goodtablesio/tests/models/test_user.py
+++ b/goodtablesio/tests/models/test_user.py
@@ -91,3 +91,22 @@ def test_update_user_stored_in_db():
     user = database['session'].query(User).get('my-id')
 
     assert user.email == 'a@a.com'
+
+
+def test_json_fields_mutable():
+
+    user = factories.User(id='my-id', provider_ids={'github': 123456},
+                          conf={'a': '1'}, _save_in_db=True)
+
+    user.provider_ids.update({'google': 'abcd'})
+    user.conf.update({'b': '2'})
+
+    database['session'].add(user)
+    database['session'].commit()
+
+    database['session'].remove()
+
+    user = database['session'].query(User).get('my-id')
+
+    assert user.provider_ids == {'google': 'abcd', 'github': 123456}
+    assert user.conf == {'a': '1', 'b': '2'}

--- a/goodtablesio/tests/models/test_user.py
+++ b/goodtablesio/tests/models/test_user.py
@@ -1,31 +1,11 @@
 import pytest
 
-from goodtablesio import models
+from goodtablesio.models.user import User
 from goodtablesio.tests import factories
 from goodtablesio.services import database
 
 
 pytestmark = pytest.mark.usefixtures('session_cleanup')
-
-
-def test_create_user_outputs_dict():
-
-    user = models.user.create({
-        'id': 'my-id',
-        'name': 'my-name',
-        'email': 'my-email@example.com',
-        'admin': True,
-        'provider_ids': {'github': '123'},
-        'conf': {'some_token': 'xxx'},
-    })
-
-    assert user['id'] == 'my-id'
-    assert user['name'] == 'my-name'
-    assert user['email'] == 'my-email@example.com'
-    assert user['admin'] is True
-    assert user['created']
-    assert user['provider_ids']['github'] == '123'
-    assert user['conf']['some_token'] == 'xxx'
 
 
 def test_create_user_stored_in_db():
@@ -38,12 +18,13 @@ def test_create_user_stored_in_db():
         'display_name': 'Test User'
     }
 
-    models.user.create(params)
+    database['session'].add(User(**params))
+    database['session'].commit()
 
     # Make sure that we are not checking the cached object in the session
     database['session'].remove()
 
-    user = database['session'].query(models.user.User).get('my-id')
+    user = database['session'].query(User).get('my-id')
 
     assert user
 
@@ -64,12 +45,13 @@ def test_create_user_stored_in_db_no_email():
         'display_name': 'Test User'
     }
 
-    models.user.create(params)
+    database['session'].add(User(**params))
+    database['session'].commit()
 
     # Make sure that we are not checking the cached object in the session
     database['session'].remove()
 
-    user = database['session'].query(models.user.User).get('my-id')
+    user = database['session'].query(User).get('my-id')
 
     assert user
 
@@ -80,132 +62,32 @@ def test_create_user_stored_in_db_no_email():
     assert user.admin is True
 
 
-def test_update_user_outputs_dict():
-
-    user = factories.User()
-
-    params = {
-        'id': user.id,
-        'name': 'some-other-name',
-        'email': 'updated@example.com',
-        'provider_ids': {'github': '123'},
-    }
-
-    updated_user = models.user.update(params)
-
-    assert updated_user['id'] == user.id
-    assert updated_user['name'] == 'some-other-name'
-    assert updated_user['email'] == 'updated@example.com'
-    assert updated_user['provider_ids']['github'] == '123'
-
-
 def test_update_user_stored_in_db():
 
-    user = factories.User()
-
     params = {
-        'id': user.id,
-        'name': 'some-other-name',
-        'email': 'updated@example.com',
+        'id': 'my-id',
+        'name': 'my-name-2',
+        'email': 'my-email-2@example.com',
+        'admin': True,
+        'display_name': 'Test User'
     }
 
-    models.user.update(params)
+    database['session'].add(User(**params))
+    database['session'].commit()
 
     # Make sure that we are not checking the cached object in the session
     database['session'].remove()
 
-    updated_user = database['session'].query(models.user.User).get(user.id)
+    user = database['session'].query(User).get('my-id')
 
-    assert updated_user
+    assert user
 
-    assert updated_user.id == user.id
-    assert updated_user.name == 'some-other-name'
-    assert updated_user.email == 'updated@example.com'
-
-
-def test_update_user_no_id_raises_value_error():
-    with pytest.raises(ValueError):
-        assert models.user.update({})
-
-
-def test_update_user_not_found_raises_value_error():
-    with pytest.raises(ValueError):
-        assert models.user.update({'id': 'not-found'})
-
-
-def test_get_user_outputs_dict():
-
-    # Actually save it to the DB so we can test retrieving it
-    user_db = factories.User(_save_in_db=True).to_dict()
+    user.email = 'a@a.com'
+    database['session'].add(user)
+    database['session'].commit()
 
     database['session'].remove()
 
-    user = models.user.get(user_db['id'])
+    user = database['session'].query(User).get('my-id')
 
-    assert user['id'] == user_db['id']
-    assert user['name'] == user_db['name']
-    assert user['display_name'] == user_db['display_name']
-    assert user['email'] == user_db['email']
-    assert user['created'] == user_db['created']
-    assert user['admin'] == user_db['admin']
-
-
-def test_get_user_not_found_outputs_none():
-
-    assert models.user.get('not-found') is None
-
-
-def test_find():
-    user1 = factories.User()
-    user2 = factories.User()
-    user3 = factories.User()
-
-    all_users = models.user.find()
-
-    assert len(all_users) == 3
-
-    assert all_users == [user3.to_dict(), user2.to_dict(), user1.to_dict()]
-
-
-def test_get_ids():
-    user1 = factories.User()
-    user2 = factories.User()
-
-    assert models.user.get_ids() == [user2.id, user1.id]
-
-
-def test_get_by_email():
-    user1 = factories.User(email='user1@example.com')
-    factories.User()
-
-    user = models.user.get_by_email('user1@example.com')
-
-    assert user['id'] == user1.id
-    assert user['email'] == user1.email
-
-
-def test_get_user_by_email_not_found_outputs_none():
-
-    assert models.user.get_by_email('not-found@example.com') is None
-
-
-def test_get_by_provider_id():
-    user1 = factories.User(provider_ids={'github': '123'})
-    factories.User(provider_ids={'google': '123'})
-
-    user = models.user.get_by_provider_id('github', '123')
-
-    assert user['id'] == user1.id
-    assert user['provider_ids']['github'] == '123'
-
-
-def test_get_user_by_provider_id_id_not_found_outputs_none():
-
-    factories.User(provider_ids={'github': '123'})
-    assert models.user.get_by_provider_id('github', 'not-found') is None
-
-
-def test_get_user_by_provider_id_name_not_found_outputs_none():
-
-    factories.User(provider_ids={'google': '123'})
-    assert models.user.get_by_provider_id('github', 'not-found') is None
+    assert user.email == 'a@a.com'

--- a/goodtablesio/tests/test_crypto.py
+++ b/goodtablesio/tests/test_crypto.py
@@ -1,7 +1,19 @@
+import pytest
 from cryptography.fernet import Fernet
 
 from goodtablesio import settings
 from goodtablesio.crypto import encrypt_string, decrypt_string
+
+
+def test_incorrect_key_encrypt():
+
+    value = b'some-text'
+    key = b'incorrect-key'
+
+    with pytest.raises(ValueError) as exc:
+        encrypt_string(value, key=key)
+
+        assert 'Wrong secret key' in str(exc)
 
 
 def test_encrypt_string():
@@ -37,6 +49,17 @@ def test_encrypt_string_transforms_to_bytes():
     token = encrypt_string(value, key=key)
 
     assert f.decrypt(token.encode('utf-8')) == value.encode('utf-8')
+
+
+def test_incorrect_key_decrypt():
+
+    token = b'some-token'
+    key = b'incorrect-key'
+
+    with pytest.raises(ValueError) as exc:
+        decrypt_string(token, key=key)
+
+        assert 'Wrong secret key' in str(exc)
 
 
 def test_decrypt_string():

--- a/goodtablesio/tests/test_crypto.py
+++ b/goodtablesio/tests/test_crypto.py
@@ -1,0 +1,77 @@
+from cryptography.fernet import Fernet
+
+from goodtablesio import settings
+from goodtablesio.crypto import encrypt_string, decrypt_string
+
+
+def test_encrypt_string():
+
+    value = b'some-text'
+    key = Fernet.generate_key()
+    f = Fernet(key)
+
+    token = encrypt_string(value, key=key)
+
+    assert isinstance(token, str)
+
+    assert f.decrypt(token.encode('utf-8')) == value
+
+
+def test_encrypt_string_uses_key_in_settings_by_default():
+
+    value = b'some-text'
+    key = settings.GTIO_SECRET_KEY
+    f = Fernet(key)
+
+    token = encrypt_string(value)
+
+    assert f.decrypt(token.encode('utf-8')) == value
+
+
+def test_encrypt_string_transforms_to_bytes():
+
+    value = 'some-text'
+    key = Fernet.generate_key()
+    f = Fernet(key)
+
+    token = encrypt_string(value, key=key)
+
+    assert f.decrypt(token.encode('utf-8')) == value.encode('utf-8')
+
+
+def test_decrypt_string():
+
+    value = b'some-text'
+    key = Fernet.generate_key()
+    f = Fernet(key)
+    token = f.encrypt(value)
+
+    our_value = decrypt_string(token, key=key)
+
+    assert isinstance(our_value, str)
+
+    assert our_value == value.decode('utf-8')
+
+
+def test_decrypt_string_uses_key_in_settings_by_default():
+
+    value = b'some-text'
+    key = settings.GTIO_SECRET_KEY
+    f = Fernet(key)
+    token = f.encrypt(value)
+
+    our_value = decrypt_string(token)
+
+    assert our_value == value.decode('utf-8')
+
+
+def test_decrypt_string_transforms_to_bytes():
+
+    value = b'some-text'
+    key = settings.GTIO_SECRET_KEY
+    f = Fernet(key)
+    token = f.encrypt(value)
+
+    our_value = decrypt_string(token.decode('utf-8'))
+
+    assert our_value == value.decode('utf-8')

--- a/migrations/versions/20170221100332_add_user_conf.py
+++ b/migrations/versions/20170221100332_add_user_conf.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '244d4ab5a66d'
+down_revision = 'e3a19aabb983'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users',
+                  sa.Column('conf', postgresql.JSONB(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('users', 'conf')

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 alembic==0.8.9
 boto3==1.4.4
 celery==4.0.0
+cryptography==1.7.2
 flask==0.11.1
 flask-login==0.4.0
 flask-oauthlib==0.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,16 @@
 #
 alembic==0.8.9
 amqp==2.1.4               # via kombu
+appdirs==1.4.0            # via setuptools
 billiard==3.5.0.2         # via celery
 boto3==1.4.4
-botocore==1.5.14          # via boto3, s3transfer
+botocore==1.5.15          # via boto3, s3transfer
 cchardet==1.1.2           # via tabulator
 celery==4.0.0
+cffi==1.9.1               # via cryptography
 click==6.7                # via flask, goodtables, jsontableschema, python-dotenv, tabulator
 contextlib2==0.5.4        # via raven
+cryptography==1.7.2
 datapackage==0.8.6        # via goodtables
 docutils==0.13.1          # via botocore
 et-xmlfile==1.0.1         # via openpyxl
@@ -24,6 +27,7 @@ future==0.16.0            # via jsontableschema
 github3.py==0.9.6
 goodtables==1.0.0a4
 gunicorn==19.6.0
+idna==2.2                 # via cryptography
 ijson==2.3                # via tabulator
 itsdangerous==0.24        # via flask
 jdcal==1.3                # via openpyxl
@@ -39,7 +43,11 @@ Mako==1.0.6               # via alembic
 MarkupSafe==0.23          # via jinja2, mako
 oauthlib==2.0.1           # via flask-oauthlib, requests-oauthlib
 openpyxl==2.4.2           # via tabulator
+packaging==16.8           # via setuptools
 psycopg2==2.6.2
+pyasn1==0.2.2             # via cryptography
+pycparser==2.17           # via cffi
+pyparsing==2.1.10         # via packaging
 python-dateutil==2.6.0    # via botocore, jsontableschema
 python-dotenv==0.6.0
 python-editor==1.0.3      # via alembic
@@ -51,7 +59,7 @@ requests-oauthlib==0.8.0  # via flask-oauthlib
 requests==2.11.1
 rfc3986==0.4.1            # via jsontableschema
 s3transfer==0.1.10        # via boto3
-six==1.10.0               # via datapackage, goodtables, jsonlines, linear-tsv, python-dateutil, tabulator
+six==1.10.0               # via cryptography, datapackage, goodtables, jsonlines, linear-tsv, packaging, python-dateutil, setuptools, tabulator
 sqlalchemy==1.1.4
 tabulator==0.14.0
 unicodecsv==0.14.1        # via datapackage, jsontableschema, tabulator
@@ -60,3 +68,6 @@ uritemplate==3.0.0        # via uritemplate.py
 vine==1.1.3               # via amqp
 Werkzeug==0.11.15         # via flask
 xlrd==1.0.0               # via tabulator
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools                # via cryptography


### PR DESCRIPTION
Fixes #132 

Rather than our hardcoded one that only works on the frictionlessdata org

This adds a new `conf ` column to the users table, and removes a lot of the model helpers that you didn't like @roll :)
Stores the oauth token in the database and not the Flask session anymore.

WIP as I still need to encrypt the tokens for security