### PR TITLE
Moved sync GitHub account control to frontend

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,8 +43,7 @@ rules:
     - error
     - except-parens
   arrow-parens:
-    - error
-    - as-needed
+    - off
   no-underscore-dangle:
     - off
   class-methods-use-this:

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ test-unit-backend: ## Run the unit tests for the backend app
 test-unit-frontend: ## Run the unit tests for the frontend app
 	NODE_ENV=testing karma start
 
+test-unit-frontend-watch: ## Run the unit tests for the frontend app
+	NODE_ENV=testing karma start --auto-watch --no-single-run
+
 test-unit: test-unit-backend test-unit-frontend ## Run all tests
 
 test-e2e: ## Run end to end tests

--- a/frontend/components/Dashboard.vue
+++ b/frontend/components/Dashboard.vue
@@ -8,7 +8,7 @@ export default {
     s3Jobs: Array,
   },
   components: {
-    'app-job-list': JobList,
+    JobList,
   },
 }
 </script>
@@ -28,7 +28,7 @@ export default {
   </div>
 
   <template v-if="githubJobs.length">
-    <app-job-list :jobs="githubJobs" />
+    <JobList :jobs="githubJobs" />
     <div style="margin-top: 20px"><a href="/github">Show more</a></div>
   </template>
 
@@ -47,7 +47,7 @@ export default {
   </div>
 
   <template v-if="s3Jobs.length">
-    <app-job-list :jobs="s3Jobs" />
+    <JobList :jobs="s3Jobs" />
     <div style="margin-top: 20px"><a href="/s3">Show more</a></div>
   </template>
 

--- a/frontend/components/GithubHome.vue
+++ b/frontend/components/GithubHome.vue
@@ -9,7 +9,7 @@ export default {
     jobs: Array,
   },
   components: {
-    'app-job-list': JobList,
+    JobList,
   },
 }
 </script>
@@ -28,7 +28,7 @@ export default {
   </div>
 
   <template v-if="jobs">
-    <app-job-list :jobs="jobs" />
+    <JobList :jobs="jobs" />
   </template>
 
   <template v-else>

--- a/frontend/components/GithubSettings.vue
+++ b/frontend/components/GithubSettings.vue
@@ -37,7 +37,7 @@ export default {
               if (!this.syncing) {
                 clearInterval(interval)
               }
-            }, 1000)
+            }, 3000)
           }
         })
     },

--- a/frontend/components/GithubSettings.vue
+++ b/frontend/components/GithubSettings.vue
@@ -5,6 +5,11 @@ export default {
     sync: Boolean,
     repos: Array,
   },
+  data: () => {
+    return {
+      isSyncingAccount: false,
+    }
+  },
 }
 </script>
 
@@ -17,7 +22,7 @@ export default {
 
   <h2>Repos</h2>
 
-  <template v-if="sync">
+  <template v-if="isSyncingAccount">
     <p><button disable class="btn btn-warning">Syncing account</button></p>
     <p>Please refresh the page after some time...</p>
   </template>

--- a/frontend/components/GithubSettings.vue
+++ b/frontend/components/GithubSettings.vue
@@ -31,14 +31,14 @@ export default {
 
   <template v-if="isSyncingAccount">
     <p><button disable class="btn btn-warning">Syncing account</button></p>
-    <p>Please refresh the page after some time...</p>
+    <p>Please wait the page will be refreshed automatically...</p>
   </template>
 
   <template v-else>
     <div style="margin-bottom: 30px" class="row">
       <div style="float: right">
         <span> Refresh your organizations and repositories</span>
-        <a href="/github/sync" class="btn btn-primary" style="width:120px;">Sync account</a>
+        <a href="/github/sync" class="btn btn-primary">Sync account</a>
       </div>
     </div>
     <template v-if="repos && repos.length">

--- a/frontend/components/GithubSettings.vue
+++ b/frontend/components/GithubSettings.vue
@@ -23,13 +23,13 @@ export default {
   </template>
 
   <template v-else>
-    <template v-if="repos && repos.length">
-      <div style="margin-bottom: 30px" class="row">
-        <div style="float: right">
-          <span> Refresh your organizations and repositories</span>
-          <a href="/github/sync" class="btn btn-primary" style="width:120px;">Sync account</a>
-        </div>
+    <div style="margin-bottom: 30px" class="row">
+      <div style="float: right">
+        <span> Refresh your organizations and repositories</span>
+        <a href="/github/sync" class="btn btn-primary" style="width:120px;">Sync account</a>
       </div>
+    </div>
+    <template v-if="repos && repos.length">
       <div v-for="repo of repos" class="row" >
         <a v-if="repo.active" :href="`/github/deactivate/${repo.id}`" class="btn btn-success">Deactivate</a>
         <a v-else :href="`/github/activate/${repo.id}`" class="btn btn-danger">Activate</a>

--- a/frontend/components/GithubSettings.vue
+++ b/frontend/components/GithubSettings.vue
@@ -1,14 +1,25 @@
 <script>
+import axios from 'axios'
+
 export default {
   name: 'GithubSettings',
   props: {
-    sync: Boolean,
     repos: Array,
   },
-  data: () => {
+  data() {
     return {
       isSyncingAccount: false,
     }
+  },
+  created() {
+    axios.get('/github/api/is_syncing_account')
+      .then(res => {
+        console.log(res)
+        this.isSyncingAccount = res.data.is_syncing_account
+      })
+      .catch(err => {
+        console.log(err)
+      })
   },
 }
 </script>

--- a/frontend/components/GithubSettings.vue
+++ b/frontend/components/GithubSettings.vue
@@ -64,7 +64,7 @@ export default {
 
     <div class="sync">
       <span> Refresh your organizations and repositories</span>
-      <a @click="syncAccount()" class="btn btn-primary">Sync account</a>
+      <button @click="syncAccount()" :disabled="!ready || syncing" class="btn btn-primary">Sync account</button>
     </div>
 
     <template v-if="repos && repos.length">

--- a/frontend/components/GithubSettings.vue
+++ b/frontend/components/GithubSettings.vue
@@ -14,11 +14,7 @@ export default {
   created() {
     axios.get('/github/api/is_syncing_account')
       .then(res => {
-        console.log(res)
         this.isSyncingAccount = res.data.is_syncing_account
-      })
-      .catch(err => {
-        console.log(err)
       })
   },
 }

--- a/frontend/components/GithubSettings.vue
+++ b/frontend/components/GithubSettings.vue
@@ -8,7 +8,7 @@ export default {
     repos: Array,
   },
   components: {
-    'app-messages': Messages,
+    Messages,
   },
   data() {
     return {
@@ -35,6 +35,7 @@ export default {
           const interval = setInterval(() => {
             this.updateIsSyncingAccount()
             if (!this.isSyncingAccount) {
+              // TODO: update repos!
               clearInterval(interval)
             }
           }, 1000)
@@ -50,8 +51,8 @@ export default {
 <template>
 <div>
 
-  <app-messages v-if="error" :messages="[['danger', error]]" />
-  <app-messages v-if="isSyncingAccount" :messages="[['warning', 'Syncing account. Please wait..']]" />
+  <Messages v-if="error" :messages="[['danger', error]]" />
+  <Messages v-if="isSyncingAccount" :messages="[['warning', 'Syncing account. Please wait..']]" />
 
   <div class="container">
 

--- a/frontend/components/Job.vue
+++ b/frontend/components/Job.vue
@@ -6,14 +6,14 @@ export default {
     job: Object,
   },
   components: {
-    'app-report': Report,
+    Report,
   },
 }
 </script>
 
 <template>
 <div class="container">
-  <app-report v-if="job.report" :report="job.report" />
+  <Report v-if="job.report" :report="job.report" />
   <p v-else>There is an error in the job!</p>
 </div>
 </template>

--- a/frontend/components/Jobs.vue
+++ b/frontend/components/Jobs.vue
@@ -7,7 +7,7 @@ export default {
     jobs: Array,
   },
   components: {
-    'app-job-list': JobList,
+    JobList,
   },
 }
 </script>
@@ -17,7 +17,7 @@ export default {
   <h1>All Jobs</h1>
 
   <template v-if="jobs">
-    <app-job-list :jobs="jobs" />
+    <JobList :jobs="jobs" />
   </template>
 
   <template v-else>

--- a/frontend/components/S3Home.vue
+++ b/frontend/components/S3Home.vue
@@ -7,7 +7,7 @@ export default {
     jobs: Array,
   },
   components: {
-    'app-job-list': JobList,
+    JobList,
   },
 }
 </script>
@@ -24,7 +24,7 @@ export default {
   </div>
 
   <template v-if="jobs">
-    <app-job-list :jobs="jobs" />
+    <JobList :jobs="jobs" />
   </template>
 
   <template v-else>

--- a/frontend/tests/GithubSettings.js
+++ b/frontend/tests/GithubSettings.js
@@ -20,6 +20,12 @@ describe('GithubSettings', () => {
     wrapper.text().should.include('There are no synced repositories')
   })
 
+  it('should have sync account button', () => {
+    const propsData = {repos: []}
+    const wrapper = mount(GithubSettings, {propsData})
+    wrapper.find('[href="/github/sync"]')[0].text().should.equal('Sync account')
+  })
+
   it('should work with sync true', () => {
     const propsData = {
       sync: true,

--- a/frontend/tests/GithubSettings.js
+++ b/frontend/tests/GithubSettings.js
@@ -49,7 +49,15 @@ describe('GithubSettings', () => {
     })
   })
 
-  it('should work while syncing account', (done) => {
+  it('should not show syncing account', (done) => {
+    const wrapper = mount(GithubSettings)
+    setTimeout(() => {
+      wrapper.text().should.not.include('Syncing account')
+      done()
+    })
+  })
+
+  it('should show syncing account on syncing', (done) => {
     mockAxios.reset()
     mockAxios.onGet('/github/api/is_syncing_account').reply(200, {
       is_syncing_account: true,

--- a/frontend/tests/GithubSettings.js
+++ b/frontend/tests/GithubSettings.js
@@ -61,7 +61,7 @@ describe('GithubSettings', () => {
     mockAxios.reset()
     mockAxios.onGet('/github/api/is_syncing_account').reply(200, {
       is_syncing_account: true,
-    });
+    })
     const wrapper = mount(GithubSettings)
     setTimeout(() => {
       wrapper.text().should.include('Syncing account')

--- a/frontend/tests/GithubSettings.js
+++ b/frontend/tests/GithubSettings.js
@@ -2,6 +2,7 @@ import axios from 'axios'
 import {should} from 'chai'
 import {mount} from 'avoriaz'
 import AxiosMockAdapter from 'axios-mock-adapter'
+import Messages from '../components/Messages.vue'
 import GithubSettings from '../components/GithubSettings.vue'
 should()
 
@@ -44,27 +45,29 @@ describe('GithubSettings', () => {
     const propsData = {repos: []}
     const wrapper = mount(GithubSettings, {propsData})
     setTimeout(() => {
-      wrapper.find('[href="/github/sync"]')[0].text().should.equal('Sync account')
+      wrapper.find('.btn')[0].text().should.equal('Sync account')
       done()
     })
   })
 
-  it('should not show syncing account', (done) => {
+  it('should not have syncing account message', (done) => {
     const wrapper = mount(GithubSettings)
     setTimeout(() => {
-      wrapper.text().should.not.include('Syncing account')
+      wrapper.find(Messages).should.has.length(0)
       done()
     })
   })
 
-  it('should show syncing account on syncing', (done) => {
+  it('should have syncing account message on syncing', (done) => {
     mockAxios.reset()
     mockAxios.onGet('/github/api/is_syncing_account').reply(200, {
       is_syncing_account: true,
     })
     const wrapper = mount(GithubSettings)
     setTimeout(() => {
-      wrapper.text().should.include('Syncing account')
+      wrapper.find(Messages).should.has.length(1)
+      wrapper.find(Messages)[0].propsData().messages
+        .should.deep.equal([['warning', 'Syncing account. Please wait..']])
       done()
     })
   })

--- a/frontend/tests/GithubSettings.js
+++ b/frontend/tests/GithubSettings.js
@@ -27,10 +27,10 @@ describe('GithubSettings', () => {
   })
 
   it('should work with sync true', () => {
-    const propsData = {
-      sync: true,
+    const data = {
+      isSyncingAccount: true,
     }
-    const wrapper = mount(GithubSettings, {propsData})
+    const wrapper = mount(GithubSettings, {data})
     wrapper.text().should.include('Syncing account')
   })
 

--- a/frontend/tests/GithubSettings.js
+++ b/frontend/tests/GithubSettings.js
@@ -13,8 +13,9 @@ describe('GithubSettings', () => {
 
   beforeEach(() => {
     mockAxios = new AxiosMockAdapter(axios)
-    mockAxios.onGet('/github/api/is_syncing_account').reply(200, {
-      is_syncing_account: false,
+    mockAxios.onGet('/github/api/repo').reply(200, {
+      syncing: false,
+      repos: [],
     })
   })
 
@@ -23,8 +24,7 @@ describe('GithubSettings', () => {
   })
 
   it('should contain headings', (done) => {
-    const propsData = {}
-    const wrapper = mount(GithubSettings, {propsData})
+    const wrapper = mount(GithubSettings)
     setTimeout(() => {
       wrapper.find('h1')[0].text().should.equal('GitHub')
       wrapper.find('h2')[0].text().should.equal('Repos')
@@ -33,8 +33,7 @@ describe('GithubSettings', () => {
   })
 
   it('should have no repositories', (done) => {
-    const propsData = {repos: []}
-    const wrapper = mount(GithubSettings, {propsData})
+    const wrapper = mount(GithubSettings)
     setTimeout(() => {
       wrapper.text().should.include('There are no synced repositories')
       done()
@@ -42,8 +41,7 @@ describe('GithubSettings', () => {
   })
 
   it('should have sync account button', (done) => {
-    const propsData = {repos: []}
-    const wrapper = mount(GithubSettings, {propsData})
+    const wrapper = mount(GithubSettings)
     setTimeout(() => {
       wrapper.find('.btn')[0].text().should.equal('Sync account')
       done()
@@ -60,8 +58,9 @@ describe('GithubSettings', () => {
 
   it('should have syncing account message on syncing', (done) => {
     mockAxios.reset()
-    mockAxios.onGet('/github/api/is_syncing_account').reply(200, {
-      is_syncing_account: true,
+    mockAxios.onGet('/github/api/repo').reply(200, {
+      syncing: true,
+      repos: [],
     })
     const wrapper = mount(GithubSettings)
     setTimeout(() => {
@@ -75,16 +74,18 @@ describe('GithubSettings', () => {
   describe('[with repos]', () => {
 
     it('should contain repos', (done) => {
-      const propsData = {
+      mockAxios.reset()
+      mockAxios.onGet('/github/api/repo').reply(200, {
+        syncing: false,
         repos: [
           {id: 'id1', name: 'name1', active: true},
           {id: 'id2', name: 'name2', active: false},
         ],
-      }
-      const wrapper = mount(GithubSettings, {propsData})
+      })
+      const wrapper = mount(GithubSettings)
       setTimeout(() => {
-        wrapper.find('[href="https://github.com/name1"]').should.has.length(1)
-        wrapper.find('[href="https://github.com/name2"]').should.has.length(1)
+        wrapper.text().should.include('name1')
+        wrapper.text().should.include('name2')
         done()
       })
     })

--- a/frontend/tests/GithubSettings.js
+++ b/frontend/tests/GithubSettings.js
@@ -131,12 +131,12 @@ describe('GithubSettings', () => {
       wrapper.find(Messages)[0].propsData().messages
         .should.deep.equal([['warning', 'Syncing account. Please wait..']])
       done()
-    }, 500)
+    }, 2000)
     setTimeout(() => {
       wrapper.text().should.include('name1')
       wrapper.text().should.include('name2')
       done()
-    }, 1500)
+    }, 4000)
   })
 
 })

--- a/frontend/tests/GithubSettings.js
+++ b/frontend/tests/GithubSettings.js
@@ -1,42 +1,69 @@
+import axios from 'axios'
 import {should} from 'chai'
 import {mount} from 'avoriaz'
+import AxiosMockAdapter from 'axios-mock-adapter'
 import GithubSettings from '../components/GithubSettings.vue'
 should()
 
 // Tests
 
 describe('GithubSettings', () => {
+  let mockAxios
 
-  it('should contain headings', () => {
+  beforeEach(() => {
+    mockAxios = new AxiosMockAdapter(axios)
+    mockAxios.onGet('/github/api/is_syncing_account').reply(200, {
+      is_syncing_account: false,
+    })
+  })
+
+  afterEach(() => {
+    mockAxios.restore()
+  })
+
+  it('should contain headings', (done) => {
     const propsData = {}
     const wrapper = mount(GithubSettings, {propsData})
-    wrapper.find('h1')[0].text().should.equal('GitHub')
-    wrapper.find('h2')[0].text().should.equal('Repos')
+    setTimeout(() => {
+      wrapper.find('h1')[0].text().should.equal('GitHub')
+      wrapper.find('h2')[0].text().should.equal('Repos')
+      done()
+    })
   })
 
-  it('should have no repositories', () => {
+  it('should have no repositories', (done) => {
     const propsData = {repos: []}
     const wrapper = mount(GithubSettings, {propsData})
-    wrapper.text().should.include('There are no synced repositories')
+    setTimeout(() => {
+      wrapper.text().should.include('There are no synced repositories')
+      done()
+    })
   })
 
-  it('should have sync account button', () => {
+  it('should have sync account button', (done) => {
     const propsData = {repos: []}
     const wrapper = mount(GithubSettings, {propsData})
-    wrapper.find('[href="/github/sync"]')[0].text().should.equal('Sync account')
+    setTimeout(() => {
+      wrapper.find('[href="/github/sync"]')[0].text().should.equal('Sync account')
+      done()
+    })
   })
 
-  it('should work with sync true', () => {
-    const data = {
-      isSyncingAccount: true,
-    }
-    const wrapper = mount(GithubSettings, {data})
-    wrapper.text().should.include('Syncing account')
+  it('should work while syncing account', (done) => {
+    mockAxios.reset()
+    mockAxios.onGet('/github/api/is_syncing_account').reply(200, {
+      is_syncing_account: true,
+    });
+    const wrapper = mount(GithubSettings)
+    setTimeout(() => {
+      wrapper.text().should.include('Syncing account')
+      done()
+    })
   })
 
   describe('[with repos]', () => {
 
-    it('should contain repos', () => {
+    it('should contain repos', (done) => {
       const propsData = {
         repos: [
           {id: 'id1', name: 'name1', active: true},
@@ -44,8 +71,11 @@ describe('GithubSettings', () => {
         ],
       }
       const wrapper = mount(GithubSettings, {propsData})
-      wrapper.find('[href="https://github.com/name1"]').should.has.length(1)
-      wrapper.find('[href="https://github.com/name2"]').should.has.length(1)
+      setTimeout(() => {
+        wrapper.find('[href="https://github.com/name1"]').should.has.length(1)
+        wrapper.find('[href="https://github.com/name2"]').should.has.length(1)
+        done()
+      })
     })
 
   })

--- a/goodtablesio/integrations/github/blueprint.py
+++ b/goodtablesio/integrations/github/blueprint.py
@@ -254,12 +254,14 @@ def api_repo_list():
 @github.route('/api/repo/<repo_id>')
 def api_repo(repo_id):
     try:
+        code = 200
         repo = database['session'].query(GithubRepo).get(repo_id).to_api()
         error = None
     except Exception:
+        code = 404
         repo = None
         error = 'Not Found'
-    return jsonify({
+    return (jsonify({
         'repo': repo,
         'error': error,
-    })
+    }), code)

--- a/goodtablesio/integrations/github/blueprint.py
+++ b/goodtablesio/integrations/github/blueprint.py
@@ -260,3 +260,22 @@ def api_is_syncing_account():
             # TODO: cover errors
             del session['github_sync_task_id']
     return jsonify({'is_syncing_account': sync})
+
+
+@github.route('/api/repo')
+@login_required
+def api_repos():
+    repos = (
+        database['session'].query(GithubRepo).
+        filter(GithubRepo.users.any(id=current_user.id)).
+        order_by(GithubRepo.active.desc(), GithubRepo.name).
+        all())
+    return jsonify({'repos': [repo.to_api() for repo in repos]})
+
+
+@github.route('/api/repo/<repo_id>')
+def api_repo(repo_id):
+    repo = database['session'].query(GithubRepo).get(repo_id)
+    if not repo:
+        return (jsonify({'error': 'Not Found'}), 404)
+    return jsonify({'repo': repo.to_api()})

--- a/goodtablesio/integrations/github/blueprint.py
+++ b/goodtablesio/integrations/github/blueprint.py
@@ -85,14 +85,13 @@ def github_settings():
 
     # Get github repos
     repos = []
-    if not sync:
-        user_id = session.get('user_id')
-        if user_id:
-            repos = (database['session'].query(GithubRepo).
-                     filter(GithubRepo.users.any(id=user_id)).
-                     order_by(GithubRepo.active.desc(),
-                              GithubRepo.name).
-                     all())
+    user_id = session.get('user_id')
+    if user_id:
+        repos = (database['session'].query(GithubRepo).
+                 filter(GithubRepo.users.any(id=user_id)).
+                 order_by(GithubRepo.active.desc(),
+                          GithubRepo.name).
+                 all())
 
     return render_component('GithubSettings', props={
         'userName': getattr(current_user, 'display_name', None),
@@ -236,9 +235,7 @@ def create_job():
 def api_sync_account():
     try:
         user_id = session['user_id']
-        # TODO: cover case when session doens't have github token
-        token = session['auth_github_token'][0]
-        result = sync_user_repos.delay(user_id, token)
+        result = sync_user_repos.delay(user_id)
         # TODO: store in the database (not session)
         # It's kinda general problem it looks like we need
         # to track syncing tasks in the database (github, s3, etc)

--- a/goodtablesio/integrations/github/models/repo.py
+++ b/goodtablesio/integrations/github/models/repo.py
@@ -7,6 +7,13 @@ class GithubRepo(Source):
         'polymorphic_identity': 'github'
     }
 
+    def to_api(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'active': self.active,
+        }
+
     @property
     def url(self):
 

--- a/goodtablesio/integrations/github/tasks/repos.py
+++ b/goodtablesio/integrations/github/tasks/repos.py
@@ -12,6 +12,7 @@ def sync_user_repos(user_id):
     """
     user = database['session'].query(User).get(user_id)
 
+    # TODO: handle no token situation
     token = user.github_oauth_token
 
     for repo_data in iter_repos_by_token(token):

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "description": "Continuous data validation, as a service.",
   "license": "AGPL-3.0",
   "dependencies": {
+    "axios": "^0.15.3",
     "vue": "^2.1.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.2",
     "avoriaz": "^1.6.0",
+    "axios-mock-adapter": "^1.7.1",
     "babel-core": "^6.0.0",
     "babel-eslint": "^7.1.1",
     "babel-loader": "^6.0.0",


### PR DESCRIPTION
- fixes [partially] #137 
- simplified vue component tag names

---

It covers github sync account without activate/deactivate logic. Also `GitHubSettings` component's tests could be used as role model for testing interactive vue components (including network dependent).

To finish #137 there is a relatively small step of moving activate/deactivate clicks to frontend. It will be addressed in separate PR.