### PR TITLE
Persist XML dev libraries in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,11 @@ RUN apk add --no-cache --virtual build-dependencies \
     postgresql-dev \
     libpng-dev \
     libjpeg-turbo-dev \
-    libxml2-dev \
-    libxslt-dev \
     libffi-dev \
  && apk add --no-cache --update \
     libstdc++ \
+    libxml2-dev \
+    libxslt-dev \
     python3 \
     bzip2 \
     bash \


### PR DESCRIPTION
Fixes #153 

They are required by lxml (requirement of tabulator) when dealing with XML based docs like ODS. Otherwise you get an exception:

```
  File "/usr/lib/python3.5/site-packages/ezodf/document.py", line 15, in <module>
    from .xmlns import subelement, CN, etree, wrap, ALL_NSMAP, fake_element
  File "/usr/lib/python3.5/site-packages/ezodf/xmlns.py", line 10, in <module>
    from lxml import etree
ImportError: Error loading shared library libxslt.so.1: No such file or directory (needed by /usr/lib/python3.5/site-packages/lxml/etree.cpython-35m-x86_64-linux-gnu.so)
```