### PR TITLE
Add job numbers

### DIFF
--- a/goodtablesio/models/job.py
+++ b/goodtablesio/models/job.py
@@ -2,7 +2,7 @@ import logging
 import datetime
 
 from sqlalchemy import (
-    Column, Unicode, DateTime, update as db_update,  ForeignKey)
+    Column, Unicode, Integer, DateTime, update as db_update,  ForeignKey)
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
@@ -23,6 +23,7 @@ class Job(Base, BaseModelMixin):
     status = Column(Unicode, default='created')
     created = Column(DateTime(timezone=True), default=datetime.datetime.utcnow)
     finished = Column(DateTime(timezone=True))
+    number = Column(Integer)
     report = Column(JSONB)
     error = Column(JSONB)
     integration_name = Column(

--- a/goodtablesio/models/source.py
+++ b/goodtablesio/models/source.py
@@ -1,7 +1,7 @@
 import datetime
 
 from sqlalchemy import (
-    Column, Unicode, DateTime, Boolean, ForeignKey, Table)
+    Column, Unicode, Integer, DateTime, Boolean, ForeignKey, Table)
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import JSONB
 
@@ -17,6 +17,7 @@ class Source(Base, BaseModelMixin):
     active = Column(Boolean, nullable=False, default=False)
     updated = Column(DateTime(timezone=True), nullable=False,
                      default=datetime.datetime.utcnow)
+    job_number = Column(Integer)
     conf = Column(JSONB)
     integration_name = Column(Unicode, ForeignKey('integrations.name'))
     integration = relationship(

--- a/goodtablesio/tests/factories.py
+++ b/goodtablesio/tests/factories.py
@@ -102,6 +102,7 @@ class Source(FactoryBase):
     name = factory.Faker('name')
     updated = factory.LazyAttribute(lambda o: datetime.datetime.utcnow())
     active = True
+    job_number = 1
 
     @property
     def integration(self):

--- a/goodtablesio/tests/models/test_job.py
+++ b/goodtablesio/tests/models/test_job.py
@@ -287,3 +287,25 @@ def test_json_fields_mutable():
     job = database['session'].query(Job).get('my-id')
 
     assert job.conf == {'a': '1', 'b': '2'}
+
+
+def test_set_job_number(celery_app):
+
+    source1 = factories.Source(integration_name='github', _save_in_db=True)
+    source2 = factories.Source(integration_name='github', _save_in_db=True)
+
+    assert source1.job_number == 1
+    assert source2.job_number == 1
+
+    job1 = factories.Job(source=source1, _save_in_db=True)
+    job2 = factories.Job(source=source1, _save_in_db=True)
+    job3 = factories.Job(source=source2, _save_in_db=True)
+    job4 = factories.Job(source=source1, _save_in_db=True)
+
+    assert source1.job_number == 4
+    assert source2.job_number == 2
+
+    assert job1.number == 1
+    assert job2.number == 2
+    assert job3.number == 1
+    assert job4.number == 3

--- a/migrations/versions/20170411163409_add_job_numbers.py
+++ b/migrations/versions/20170411163409_add_job_numbers.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '89177f936b9b'
+down_revision = '384743329d34'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('jobs', sa.Column('number', sa.Integer(), nullable=True))
+    op.add_column('sources', sa.Column('job_number', sa.Integer(),
+                  nullable=True))
+
+    statement1 = '''
+        UPDATE jobs SET number = tmp_jobs.rn
+        FROM (
+            SELECT ROW_NUMBER() OVER (PARTITION BY jobs.source_id
+                                      ORDER BY finished) rn, id
+            FROM jobs) AS tmp_jobs
+        WHERE jobs.id = tmp_jobs.id
+    '''
+    op.execute(statement1)
+
+    statement2 = '''
+    UPDATE sources AS s SET job_number = 1
+    '''
+    op.execute(statement2)
+
+    statement3 = '''
+    UPDATE sources AS s SET job_number = (
+        SELECT MAX(j.number) + 1 FROM jobs AS j WHERE s.id = j.source_id)
+    WHERE s.active = 't'
+    '''
+    op.execute(statement3)
+
+    statement4 = '''
+    CREATE OR REPLACE FUNCTION add_job_number()
+        RETURNS trigger LANGUAGE plpgsql AS
+    $BODY$
+    DECLARE
+        next_value integer;
+    BEGIN
+
+        SELECT job_number FROM sources WHERE id = NEW.source_id INTO next_value;
+
+        UPDATE sources SET job_number = job_number + 1 WHERE id = NEW.source_id;
+
+        NEW.number = next_value;
+
+        RETURN NEW;
+
+    END;
+    $BODY$
+    '''
+    op.execute(statement4)
+
+    statement5 = '''
+    CREATE TRIGGER job_number
+        BEFORE INSERT
+        ON jobs
+        FOR EACH ROW
+        EXECUTE PROCEDURE add_job_number();
+    '''
+    op.execute(statement5)
+
+
+def downgrade():
+    op.execute('DROP TRIGGER IF EXISTS job_number ON jobs')
+    op.execute('DROP FUNCTION IF EXISTS add_job_number()')
+    op.drop_column('jobs', 'number')
+    op.drop_column('sources', 'job_number')


### PR DESCRIPTION
This adds a serial integer to each job depending on its source. Anything done at the application level may be prone to duplicates or conflicts, or force us to do it on a separate queue, so I decided to use Postgres amazing triggers to do the job.