### PR TITLE
Improve validation logic for JSON files

### DIFF
--- a/goodtablesio/models/job.py
+++ b/goodtablesio/models/job.py
@@ -137,7 +137,7 @@ def find(filters=None, limit=10, offset=0):
 
     q = database['session'].query(Job)
 
-    limit = limit or settings.MAX_JOBS_LIMIT
+    limit = limit or settings.JOBS_LIMIT_FOR_FIND_QUERY
 
     if filters:
         for _filter in filters:

--- a/goodtablesio/settings.py
+++ b/goodtablesio/settings.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 BASE_URL = os.environ['BASE_URL']
 DEBUG = os.environ.get('FLASK_DEBUG', False)
 GTIO_SECRET_KEY = os.environ['GTIO_SECRET_KEY']
+GLOB_EXCLUDED_FORMATS = ['json']
 
 # Flask
 
@@ -28,15 +29,13 @@ FLASK_SECRET_KEY = os.environ['FLASK_SECRET_KEY']
 
 # Database
 
+JOBS_LIMIT_FOR_FIND_QUERY = 100
 if not os.environ.get('TESTING'):
     log.debug('Not testing mode')
     DATABASE_URL = os.environ['DATABASE_URL']
 else:
     log.debug('Testing mode')
     DATABASE_URL = os.environ['TEST_DATABASE_URL']
-
-# Maximum limit on all job queries
-MAX_JOBS_LIMIT = 100
 
 # Celery
 
@@ -53,7 +52,6 @@ enable_utc = True
 GITHUB_API_BASE = 'https://api.github.com'
 GITHUB_API_TOKEN = os.environ['GITHUB_API_TOKEN']
 GITHUB_HOOK_SECRET = os.environ['GITHUB_HOOK_SECRET']
-
 
 # S3
 

--- a/goodtablesio/tests/utils/test_jobconf.py
+++ b/goodtablesio/tests/utils/test_jobconf.py
@@ -214,6 +214,23 @@ def test_make_validation_conf_files_and_datapackages():
         make_validation_conf(job_conf_text, job_files, job_base)
 
 
+def test_make_validation_conf_infer_datapackage_json():
+    job_conf_text = None
+    job_files = [
+        'file1.csv',
+        'file2.csv',
+        'datapackage.json',
+    ]
+    job_base = 'http://example.com'
+    validation_conf = {
+        'source': [
+            {'source': 'http://example.com/datapackage.json', 'preset': 'datapackage'},
+        ]
+    }
+
+    assert make_validation_conf(job_conf_text, job_files, job_base) == validation_conf
+
+
 def test_verify_validation_conf():
     validation_conf = {
         'source': [

--- a/goodtablesio/tests/utils/test_jobconf.py
+++ b/goodtablesio/tests/utils/test_jobconf.py
@@ -3,7 +3,7 @@ from goodtablesio import exceptions
 from goodtablesio.utils.jobconf import make_validation_conf, verify_validation_conf
 
 
-# Tests
+# Make validation conf
 
 def test_make_validation_conf():
     job_conf_text = """
@@ -26,7 +26,7 @@ def test_make_validation_conf():
     validation_conf = {
         'source': [
             {'source': 'http://example.com/file.csv'},
-            {'source': 'http://example.com/file.json'},
+            # {'source': 'http://example.com/file.json'},
             {'source': 'http://example.com/file.jsonl'},
             {'source': 'http://example.com/file.ndjson'},
             {'source': 'http://example.com/file.tsv'},
@@ -60,7 +60,7 @@ def test_make_validation_conf_no_base():
     validation_conf = {
         'source': [
             {'source': 'file.csv'},
-            {'source': 'file.json'},
+            # {'source': 'file.json'},
             {'source': 'file.jsonl'},
             {'source': 'file.ndjson'},
             {'source': 'file.tsv'},
@@ -88,7 +88,6 @@ def test_make_validation_conf_subdir():
             {'source': 'http://example.com/data/file.csv'},
         ]
     }
-
     assert make_validation_conf(job_conf_text, job_files, job_base) == validation_conf
 
 
@@ -107,7 +106,6 @@ def test_make_validation_conf_subdir_config():
             {'source': 'http://example.com/data/file.csv'},
         ]
     }
-
     assert make_validation_conf(job_conf_text, job_files, job_base) == validation_conf
 
 
@@ -141,7 +139,6 @@ def test_make_validation_conf_subdir_granular():
             'order_fields': True,
         }
     }
-
     assert make_validation_conf(job_conf_text, job_files, job_base) == validation_conf
 
 
@@ -159,7 +156,6 @@ def test_make_validation_conf_default_job_conf():
             {'source': 'http://example.com/file2.csv'},
         ]
     }
-
     assert make_validation_conf(job_conf_text, job_files, job_base) == validation_conf
 
 
@@ -180,7 +176,6 @@ def test_make_validation_conf_datapackages():
             {'source': 'http://example.com/datapackage2.json', 'preset': 'datapackage'},
         ]
     }
-
     assert make_validation_conf(job_conf_text, job_files, job_base) == validation_conf
 
 
@@ -198,7 +193,6 @@ def test_make_validation_conf_files_and_datapackages():
         'datapackage2.json',
     ]
     job_base = 'http://example.com'
-
     # https://github.com/frictionlessdata/goodtables.io/issues/169
     # validation_conf = {
         # 'source': [
@@ -209,7 +203,6 @@ def test_make_validation_conf_files_and_datapackages():
         # ]
     # }
     # assert make_validation_conf(job_conf_text, job_files, job_base) == validation_conf
-
     with pytest.raises(exceptions.InvalidJobConfiguration):
         make_validation_conf(job_conf_text, job_files, job_base)
 
@@ -227,9 +220,44 @@ def test_make_validation_conf_infer_datapackage_json():
             {'source': 'http://example.com/datapackage.json', 'preset': 'datapackage'},
         ]
     }
-
     assert make_validation_conf(job_conf_text, job_files, job_base) == validation_conf
 
+
+def test_make_validation_conf_glob_exlude_json_files():
+    job_conf_text = """
+    files: '*'
+    """
+    job_files = [
+        'data.csv',
+        'data.json',
+    ]
+    job_base = 'http://example.com'
+    validation_conf = {
+        'source': [
+            {'source': 'http://example.com/data.csv'},
+        ]
+    }
+    assert make_validation_conf(job_conf_text, job_files, job_base) == validation_conf
+
+
+def test_make_validation_conf_glob_include_json_files_using_pattern():
+    job_conf_text = """
+    files: '*.json'
+    """
+    job_files = [
+        'data.csv',
+        'data.json',
+    ]
+    job_base = 'http://example.com'
+    validation_conf = {
+        'source': [
+            {'source': 'http://example.com/data.json'},
+        ]
+    }
+    assert make_validation_conf(job_conf_text, job_files, job_base) == validation_conf
+
+
+# Verify validation conf
 
 def test_verify_validation_conf():
     validation_conf = {
@@ -238,7 +266,6 @@ def test_verify_validation_conf():
             {'source': 'http://example.com/datapackage.json', 'preset': 'datapackage'},
         ]
     }
-
     assert verify_validation_conf(validation_conf)
 
 
@@ -248,7 +275,6 @@ def test_verify_validation_conf_invalid_bad_preset():
             {'source': 'http://example.com/file.csv', 'preset': 'bad-preset'},
         ]
     }
-
     with pytest.raises(exceptions.InvalidValidationConfiguration):
         verify_validation_conf(validation_conf)
 
@@ -257,6 +283,5 @@ def test_verify_validation_conf_invalid_empty_source():
     validation_conf = {
         'source': []
     }
-
     with pytest.raises(exceptions.InvalidValidationConfiguration):
         verify_validation_conf(validation_conf)

--- a/goodtablesio/utils/jobconf.py
+++ b/goodtablesio/utils/jobconf.py
@@ -32,7 +32,10 @@ def make_validation_conf(job_conf_text, job_files, job_base=None):
     # Parse, set defaults and verify job conf
     job_conf = _parse_job_conf(job_conf_text) or {}
     if not job_conf.get('files', job_conf.get('datapackages')):
-        job_conf['files'] = '*'
+        if 'datapackage.json' in job_files:
+            job_conf['datapackages'] = ['datapackage.json']
+        else:
+            job_conf['files'] = '*'
     _verify_job_conf(job_conf)
 
     # Files: string

--- a/goodtablesio/utils/jobconf.py
+++ b/goodtablesio/utils/jobconf.py
@@ -4,6 +4,7 @@ import yaml
 import jsonschema
 from fnmatch import fnmatch
 from tabulator import Stream
+from goodtablesio import settings
 from goodtablesio import exceptions
 
 
@@ -42,15 +43,16 @@ def make_validation_conf(job_conf_text, job_files, job_base=None):
     if isinstance(job_conf.get('files'), str):
         pattern = job_conf['files']
         for name in job_files:
-            if not Stream.test(name):
+            if not _is_glob_supported_format(name, pattern):
                 continue
-            if fnmatch(name, pattern):
-                source = name
-                if job_base:
-                    source = '/'.join([job_base, name])
-                validation_conf['source'].append({
-                    'source': source,
-                })
+            if not fnmatch(name, pattern):
+                continue
+            source = name
+            if job_base:
+                source = '/'.join([job_base, name])
+            validation_conf['source'].append({
+                'source': source,
+            })
 
     # Files: array of objects
     elif isinstance(job_conf.get('files'), list):
@@ -133,4 +135,17 @@ def _verify_conf(conf, schema):
          os.path.dirname(__file__), '..', 'schemas', schema)
     schema = yaml.load(io.open(schema_path, encoding='utf-8'))
     jsonschema.validate(conf, schema)
+    return True
+
+
+def _is_glob_supported_format(name, pattern):
+    """Check if this file is supported
+    """
+    for format in settings.GLOB_EXCLUDED_FORMATS:
+        if format in pattern:
+            continue
+        if format == os.path.splitext(name.lower())[1][1:]:
+            return False
+    if not Stream.test(name):
+        return False
     return True


### PR DESCRIPTION
- fixes #189 

---

With this PR:
- it infers data package if there is `datapackage.json` file in source root
- it excludes JSON files for glob patterns like `files: *` (or no `goodtables.yml`)
- it still includes JSON files for glob patterns like `files: *.json`
- it do nothing with granular file selection so user could add JSON as `files: [data.json]`

I suppose we should ignore JSON files for glob by default because it's mostly used for configuration, package.json etc. It's tabular only if special structure is used (array of objects/arrays). So I guess for 99% of users it will be good default. If it makes we have to add a note to user docs for this special case.