### PR TITLE
Start repo validation on activation

### DIFF
--- a/goodtablesio/integrations/github/blueprint.py
+++ b/goodtablesio/integrations/github/blueprint.py
@@ -175,6 +175,10 @@ def api_repo_activate(repo_id):
             error = 'Repo activation error'
             log.exception(exception)
 
+    # Validate repo
+    if not error:
+        repo.create_and_start_job()
+
     return jsonify({
         'error': error,
     })

--- a/goodtablesio/integrations/github/models/repo.py
+++ b/goodtablesio/integrations/github/models/repo.py
@@ -1,5 +1,14 @@
+import uuid
+import logging
+from goodtablesio.services import database
+from goodtablesio.models.job import Job
 from goodtablesio.models.source import Source
+from goodtablesio.integrations.github.utils.status import set_commit_status
+from goodtablesio.integrations.github.utils.validation import run_validation
+log = logging.getLogger(__name__)
 
+
+# Module API
 
 class GithubRepo(Source):
 
@@ -9,22 +18,57 @@ class GithubRepo(Source):
 
     @property
     def url(self):
-
         parts = self.name.split('/')
-
         template = 'https://github.com/{owner}/{repo}'
         return template.format(owner=parts[0], repo=parts[1])
 
     @property
     def owner(self):
-
         parts = self.name.split('/')
-
         return parts[0]
 
     @property
     def repo(self):
-
         parts = self.name.split('/')
-
         return parts[1]
+
+    @property
+    def tokens(self):
+        return [user.github_oauth_token for user in self.users
+            if user.github_oauth_token]
+
+    def create_and_start_job(self, conf=None):
+
+        # Get tokens
+        if not self.tokens:
+            log.error('No GitHub tokens available to perform the job')
+            return None
+
+        # Save job to database
+        job_id = str(uuid.uuid4())
+        params = {
+            'id': job_id,
+            'integration_name': 'github',
+            'source_id': self.id,
+            'conf': conf
+        }
+        job = Job(**params)
+        job.source = self
+        database['session'].add(job)
+        database['session'].commit()
+
+        # Set GitHub status
+        set_commit_status(
+            'pending',
+            owner=conf['owner'],
+            repo=conf['repo'],
+            sha=conf['sha'],
+            job_number=job.number,
+            is_pr=conf['is_pr'],
+            tokens=self.tokens)
+
+        # Run validation
+        run_validation(conf['owner'], conf['repo'], conf['sha'],
+            job_id=job_id, tokens=self.tokens)
+
+        return job_id

--- a/goodtablesio/integrations/github/models/repo.py
+++ b/goodtablesio/integrations/github/models/repo.py
@@ -5,6 +5,7 @@ from goodtablesio.models.job import Job
 from goodtablesio.models.source import Source
 from goodtablesio.integrations.github.utils.status import set_commit_status
 from goodtablesio.integrations.github.utils.validation import run_validation
+from goodtablesio.integrations.github.utils.repos import get_default_repo_details
 log = logging.getLogger(__name__)
 
 
@@ -43,6 +44,13 @@ class GithubRepo(Source):
         if not self.tokens:
             log.error('No GitHub tokens available to perform the job')
             return None
+
+        # Get default repo details
+        if not conf:
+            conf = get_default_repo_details(self.owner, self.repo, token=self.tokens[0])
+            if not conf:
+                log.error('No default repo details are available')
+                return None
 
         # Save job to database
         job_id = str(uuid.uuid4())

--- a/goodtablesio/integrations/github/models/user.py
+++ b/goodtablesio/integrations/github/models/user.py
@@ -1,8 +1,9 @@
 import cryptography
-
 from goodtablesio.crypto import encrypt_string, decrypt_string
 from goodtablesio.models.user import User
 
+
+# Helpers
 
 def get_token(self):
     token = self.conf.get('github_oauth_token')
@@ -27,7 +28,7 @@ def del_token(self):
     del self.conf['github_oauth_token']
 
 
-github_oauth_token = property(
-    get_token, set_token, del_token, 'GitHub OAuth Token')
+# Module API
 
-setattr(User, 'github_oauth_token', github_oauth_token)
+setattr(User, 'github_oauth_token', property(
+    get_token, set_token, del_token, 'GitHub OAuth Token'))

--- a/goodtablesio/integrations/github/signals.py
+++ b/goodtablesio/integrations/github/signals.py
@@ -1,11 +1,11 @@
 from celery import signals
-
 from goodtablesio.services import database
 from goodtablesio.models.job import Job
 from goodtablesio.tasks.validate import validate
 from goodtablesio.integrations.github.utils.status import set_commit_status
-from goodtablesio.integrations.github.utils.hook import get_tokens_for_job
 
+
+# Module API
 
 @signals.task_postrun.connect(sender=validate)
 def post_task_handler(**kwargs):
@@ -25,8 +25,6 @@ def post_task_handler(**kwargs):
         else:
             github_status = 'error'
 
-        tokens = get_tokens_for_job(job)
-
         set_commit_status(
            github_status,
            owner=job.conf['owner'],
@@ -34,4 +32,4 @@ def post_task_handler(**kwargs):
            sha=job.conf['sha'],
            job_number=job.number,
            is_pr=job.conf['is_pr'],
-           tokens=tokens)
+           tokens=job.source.tokens)

--- a/goodtablesio/integrations/github/tasks/repos.py
+++ b/goodtablesio/integrations/github/tasks/repos.py
@@ -9,6 +9,8 @@ from goodtablesio.integrations.github.models.repo import GithubRepo
 from goodtablesio.integrations.github.utils.repos import iter_repos_by_token
 
 
+# Module API
+
 @celery_app.task(name='goodtablesio.github.sync_user_repos',
                  queue='internal', base=InternalJobTask)
 def sync_user_repos(user_id, job_id):
@@ -67,6 +69,8 @@ def sync_user_repos(user_id, job_id):
     # Commit to database
     database['session'].commit()
 
+
+# Internal
 
 def _can_see_private_repos(user, repo_data):
     # TODO: check that there is any subscription that gives access to this

--- a/goodtablesio/integrations/github/utils/hook.py
+++ b/goodtablesio/integrations/github/utils/hook.py
@@ -72,8 +72,3 @@ def get_details_from_hook_payload(payload):
         return None
 
     return details
-
-
-def get_tokens_for_job(job):
-    return [user.github_oauth_token
-            for user in job.source.users if user.github_oauth_token]

--- a/goodtablesio/integrations/github/utils/repos.py
+++ b/goodtablesio/integrations/github/utils/repos.py
@@ -1,4 +1,6 @@
+import logging
 from github3 import GitHub
+log = logging.getLogger(__name__)
 
 
 # Module API
@@ -22,3 +24,29 @@ def iter_repos_by_token(token):
             },
             'active': active
         }
+
+
+def get_default_repo_details(owner, repo, token):
+    """Return defaults repo details.
+    """
+    try:
+        client = GitHub(token=token)
+        repo_client = client.repository(owner, repo)
+        branch_client = repo_client.branch(repo_client.default_branch)
+        branch_data = branch_client.to_json()
+        branch_name = branch_data['name']
+        author_name = branch_data['commit']['author']['login']
+        commit_message = branch_data['commit']['commit']['message']
+        sha = branch_data['commit']['sha']
+    except Exception as exception:
+        log.exception(exception)
+        return None
+    return {
+        'is_pr': False,
+        'owner': owner,
+        'repo': repo,
+        'sha': sha,
+        'branch_name': branch_name,
+        'author_name': author_name,
+        'commit_message': commit_message,
+    }

--- a/goodtablesio/integrations/github/utils/validation.py
+++ b/goodtablesio/integrations/github/utils/validation.py
@@ -1,0 +1,14 @@
+from celery import chain
+from goodtablesio.tasks.validate import validate
+from goodtablesio.integrations.github.tasks.jobconf import get_validation_conf
+
+
+# Module API
+
+def run_validation(owner, repo, sha, job_id, tokens):
+    """Starts validation tasks on queue
+    """
+    tasks_chain = chain(
+        get_validation_conf.s(owner, repo, sha, job_id=job_id, tokens=tokens),
+        validate.s(job_id=job_id))
+    tasks_chain.delay()

--- a/goodtablesio/tests/integrations/github/test_blueprint.py
+++ b/goodtablesio/tests/integrations/github/test_blueprint.py
@@ -12,8 +12,8 @@ pytestmark = pytest.mark.usefixtures('session_cleanup')
 
 
 # Tests
-@mock.patch('goodtablesio.integrations.github.blueprint._run_validation')
-@mock.patch('goodtablesio.integrations.github.blueprint.set_commit_status')
+@mock.patch('goodtablesio.integrations.github.models.repo.run_validation')
+@mock.patch('goodtablesio.integrations.github.models.repo.set_commit_status')
 def test_create_job_push(run_validation, set_commit_status, client):
 
     user = factories.User(github_oauth_token='xxx')
@@ -43,8 +43,8 @@ def test_create_job_push(run_validation, set_commit_status, client):
     assert job['status'] == 'created'
 
 
-@mock.patch('goodtablesio.integrations.github.blueprint._run_validation')
-@mock.patch('goodtablesio.integrations.github.blueprint.set_commit_status')
+@mock.patch('goodtablesio.integrations.github.models.repo.run_validation')
+@mock.patch('goodtablesio.integrations.github.models.repo.set_commit_status')
 def test_create_job_pr(run_validation, set_commit_status, client):
 
     user = factories.User(github_oauth_token='xxx')
@@ -82,7 +82,9 @@ def test_create_job_pr(run_validation, set_commit_status, client):
     assert job['status'] == 'created'
 
 
-def test_create_job_pr_other_action(client):
+@mock.patch('goodtablesio.integrations.github.models.repo.run_validation')
+@mock.patch('goodtablesio.integrations.github.models.repo.set_commit_status')
+def test_create_job_pr_other_action(run_validation, set_commit_status, client):
 
     user = factories.User(github_oauth_token='xxx')
     source = factories.GithubRepo(name='test-org/example',
@@ -117,8 +119,8 @@ def test_create_job_pr_other_action(client):
     assert len(source.jobs) == 0
 
 
-@mock.patch('goodtablesio.integrations.github.blueprint._run_validation')
-@mock.patch('goodtablesio.integrations.github.blueprint.set_commit_status')
+@mock.patch('goodtablesio.integrations.github.models.repo.run_validation')
+@mock.patch('goodtablesio.integrations.github.models.repo.set_commit_status')
 def test_create_job_pr_from_fork(run_validation, set_commit_status, client):
 
     user = factories.User(github_oauth_token='xxx')

--- a/goodtablesio/tests/integrations/github/test_blueprint.py
+++ b/goodtablesio/tests/integrations/github/test_blueprint.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.usefixtures('session_cleanup')
 # Tests
 @mock.patch('goodtablesio.integrations.github.models.repo.run_validation')
 @mock.patch('goodtablesio.integrations.github.models.repo.set_commit_status')
-def test_create_job_push(run_validation, set_commit_status, client):
+def test_create_job_push(set_commit_status, run_validation, client):
 
     user = factories.User(github_oauth_token='xxx')
     factories.GithubRepo(name='test-org/example',
@@ -45,7 +45,7 @@ def test_create_job_push(run_validation, set_commit_status, client):
 
 @mock.patch('goodtablesio.integrations.github.models.repo.run_validation')
 @mock.patch('goodtablesio.integrations.github.models.repo.set_commit_status')
-def test_create_job_pr(run_validation, set_commit_status, client):
+def test_create_job_pr(set_commit_status, run_validation, client):
 
     user = factories.User(github_oauth_token='xxx')
     factories.GithubRepo(name='test-org/example',
@@ -84,7 +84,7 @@ def test_create_job_pr(run_validation, set_commit_status, client):
 
 @mock.patch('goodtablesio.integrations.github.models.repo.run_validation')
 @mock.patch('goodtablesio.integrations.github.models.repo.set_commit_status')
-def test_create_job_pr_other_action(run_validation, set_commit_status, client):
+def test_create_job_pr_other_action(set_commit_status, run_validation, client):
 
     user = factories.User(github_oauth_token='xxx')
     source = factories.GithubRepo(name='test-org/example',
@@ -121,7 +121,7 @@ def test_create_job_pr_other_action(run_validation, set_commit_status, client):
 
 @mock.patch('goodtablesio.integrations.github.models.repo.run_validation')
 @mock.patch('goodtablesio.integrations.github.models.repo.set_commit_status')
-def test_create_job_pr_from_fork(run_validation, set_commit_status, client):
+def test_create_job_pr_from_fork(set_commit_status, run_validation, client):
 
     user = factories.User(github_oauth_token='xxx')
     factories.GithubRepo(name='test-org/example',
@@ -277,7 +277,12 @@ def test_api_repo_list(client):
 
 
 @mock.patch('goodtablesio.integrations.github.blueprint.activate_hook')
-def test_api_repo_activate(activate_hook, client):
+@mock.patch('goodtablesio.integrations.github.models.repo.run_validation')
+@mock.patch('goodtablesio.integrations.github.models.repo.set_commit_status')
+@mock.patch('goodtablesio.integrations.github.models.repo.get_default_repo_details')
+def test_api_repo_activate(get_default_repo_details, set_commit_status,
+        run_validation, activate_hook, client):
+    get_default_repo_details.return_value = None
     user = factories.User(github_oauth_token='token')
     repo = factories.GithubRepo(name='owner/repo', users=[user])
     with client.session_transaction() as session:


### PR DESCRIPTION
- connects #210
  - start repo validation on activation
- small improvements for control flow in github integration

---

For my piloting and fixing goodtables.io bugs work I've found almost blocking situation that you need to **modify** repository to get validation results (sometimes it's just not possible). 

So for now I've added a trigger to start first validation on default branch straight after repo activation (also we could deactivate/activate repo to trigger validation at any time for any repo - priceless for testing).

It was a trivial change. Let's discuss later in #210 should we keep it or not. But I think for our non-technical users having immediate feedback from the system is essential. We just should add a note about it to `Manage Sources` page.