### PR TITLE
Fixed how we set/check GitHub hooks

### DIFF
--- a/goodtablesio/integrations/github/utils/hook.py
+++ b/goodtablesio/integrations/github/utils/hook.py
@@ -11,9 +11,7 @@ def activate_hook(token, owner, repo):
     config = {
         'content_type': 'json',
         'secret': settings.GITHUB_HOOK_SECRET,
-        # We can't use url_for here because there is no app context
-        'url': '%s/github/hook' % settings.BASE_URL,
-        'is_goodtables_hook': True,
+        'url': settings.GITHUB_HOOK_URL,
     }
     events = [
         'pull_request',

--- a/goodtablesio/integrations/github/utils/repos.py
+++ b/goodtablesio/integrations/github/utils/repos.py
@@ -1,5 +1,6 @@
 import logging
 from github3 import GitHub
+from goodtablesio import settings
 log = logging.getLogger(__name__)
 
 
@@ -13,7 +14,7 @@ def iter_repos_by_token(token):
         active = False
         data = repo.to_json()
         for hook in repo.iter_hooks():
-            if hook.config.get('is_goodtables_hook'):
+            if hook.config.get('url') == settings.GITHUB_HOOK_URL:
                 active = True
         yield {
             'integration_name': 'github',

--- a/goodtablesio/settings.py
+++ b/goodtablesio/settings.py
@@ -54,6 +54,7 @@ enable_utc = True
 GITHUB_API_BASE = 'https://api.github.com'
 GITHUB_API_TOKEN = os.environ['GITHUB_API_TOKEN']
 GITHUB_HOOK_SECRET = os.environ['GITHUB_HOOK_SECRET']
+GITHUB_HOOK_URL = '%s/github/hook' % BASE_URL
 
 # S3
 

--- a/goodtablesio/tests/integrations/github/conftest.py
+++ b/goodtablesio/tests/integrations/github/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from goodtablesio import settings
 from unittest.mock import Mock, patch
 
 
@@ -15,7 +16,7 @@ def GitHubForIterRepos():
         },
         'private': False
     }))
-    hook1 = Mock(config=Mock(get=Mock(return_value=True)))
+    hook1 = Mock(config={'url': settings.GITHUB_HOOK_URL})
     repo1.iter_hooks.return_value = [hook1]
     repo2 = Mock(to_json=Mock(return_value={
         'id': 'id2',
@@ -25,7 +26,7 @@ def GitHubForIterRepos():
         },
         'private': False
     }))
-    hook2 = Mock(config=Mock(get=Mock(return_value=False)))
+    hook2 = Mock(config={'url': 'http://example.com'})
     repo2.iter_hooks.return_value = [hook2]
     repo3 = Mock(to_json=Mock(return_value={
         'id': 'id3',
@@ -35,7 +36,7 @@ def GitHubForIterRepos():
         },
         'private': True
     }))
-    hook3 = Mock(config=Mock(get=Mock(return_value=False)))
+    hook3 = Mock(config={})
     repo3.iter_hooks.return_value = [hook3]
 
     GitHub.return_value.iter_repos.return_value = [repo1, repo2, repo3]

--- a/goodtablesio/tests/integrations/github/utils/test_hook.py
+++ b/goodtablesio/tests/integrations/github/utils/test_hook.py
@@ -12,9 +12,8 @@ def test_activate_hook(GitHub):
     GitHub.return_value.repository.return_value.create_hook.assert_called_with('web',
         config={
             'secret': settings.GITHUB_HOOK_SECRET,
-            'url': '%s/github/hook' % settings.BASE_URL,
+            'url': settings.GITHUB_HOOK_URL,
             'content_type': 'json',
-            'is_goodtables_hook': True,
         }, events=['pull_request', 'push'])
 
 


### PR DESCRIPTION
- fixes #90

---

With this fix we have independent hooks for different environments like:
- development
- staging
- production

We have stable domain names / url structure so checking for the hook url is pretty enough for now.