### PR TITLE
[#296] Allow validation of uploaded data packages

### DIFF
--- a/goodtablesio/tasks/validate.py
+++ b/goodtablesio/tasks/validate.py
@@ -32,7 +32,7 @@ def validate(validation_conf, job_id, files={}):
 
     # Add uploaded files
     for item in validation_conf['source']:
-        if item.get('preset', 'table') == 'table':
+        if item.get('preset', 'table') in ['table', 'datapackage']:
             item['scheme'] = 'http'
             if item['source'] in files:
                 item['scheme'] = 'file'

--- a/goodtablesio/tests/blueprints/test_api.py
+++ b/goodtablesio/tests/blueprints/test_api.py
@@ -184,14 +184,14 @@ def test_api_source_job_create(post):
     assert job.source == source
 
 
-def test_api_source_job_create_file_upload(celery_app, post_form):
+def test_api_source_job_create_file_upload(celery_app, post_form, sample_csv, sample_tableschema):
     user = factories.User()
     token = user.create_api_token()
     source = factories.Source(users=[user], integration_name='api')
     payload = {
         'data': json.dumps({'source': [{'source': 'file1', 'schema': 'file2'}]}),
-        'file1': (open('goodtablesio/tests/fixtures/data.csv', 'rb'), 'data.csv'),
-        'file2': (open('goodtablesio/tests/fixtures/schema.json', 'rb'), 'schema.json'),
+        'file1': (sample_csv, 'data.csv'),
+        'file2': (sample_tableschema, 'schema.json'),
     }
     code, data = post_form('/api/source/%s/job' % source.id, payload, token=token.token)
     job = Job.get(data['job']['id'])

--- a/goodtablesio/tests/conftest.py
+++ b/goodtablesio/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from goodtablesio.app import app
 from goodtablesio.services import database
 from goodtablesio.models.job import Job
@@ -11,6 +12,9 @@ from goodtablesio.celery_app import celery_app as celapp
 
 
 # Fixture
+
+FIXTURES_PATH = os.path.join(os.path.dirname(__file__), 'fixtures')
+
 
 def pytest_configure(config):
 
@@ -50,3 +54,21 @@ def celery_app():
     celapp.conf['task_always_eager'] = True
 
     return celapp
+
+
+@pytest.fixture()
+def sample_datapackage():
+    path = os.path.join(FIXTURES_PATH, 'datapackage.json')
+    yield open(path, 'rb')
+
+
+@pytest.fixture()
+def sample_csv():
+    path = os.path.join(FIXTURES_PATH, 'data.csv')
+    yield open(path, 'rb')
+
+
+@pytest.fixture()
+def sample_tableschema():
+    path = os.path.join(FIXTURES_PATH, 'schema.json')
+    yield open(path, 'rb')

--- a/goodtablesio/tests/fixtures/datapackage.json
+++ b/goodtablesio/tests/fixtures/datapackage.json
@@ -1,0 +1,21 @@
+{
+  "name": "sample-datapackage",
+  "resources": [
+    {
+      "name": "resource0",
+      "path": "data.csv",
+      "schema": {
+        "fields": [
+          {
+            "name": "id",
+            "type": "integer"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/goodtablesio/tests/tasks/test_validate.py
+++ b/goodtablesio/tests/tasks/test_validate.py
@@ -39,6 +39,23 @@ def test_validate(_inspect):
     assert isinstance(updated_job['finished'], datetime.datetime)
 
 
+def test_validate_datapackage_file(sample_datapackage):
+    job = factories.Job(_save_in_db=True)
+    validation_conf = {
+        'source': [
+            {'preset': 'datapackage', 'source': 'file0'},
+        ],
+        'settings': {},
+    }
+    files = {
+        'file0': sample_datapackage.name,
+    }
+
+    job = validate(validation_conf, job.id, files)
+
+    assert job['error'] is None
+
+
 @pytest.mark.skip('now we enforce http scheme')
 def test_validate_skip_rows():
     source = 'text://a,b\n1,2\n#comment'

--- a/package-lock.json
+++ b/package-lock.json
@@ -5251,9 +5251,9 @@
       }
     },
     "goodtables-ui": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/goodtables-ui/-/goodtables-ui-1.2.0.tgz",
-      "integrity": "sha512-V0wn2/8lvx6W38RlBKI03bgiD380qY94v/zZBYl10MQEDdBNuKzlZK1z9fJe+a1FIMgH5mOWgbCh6YJG6/6jfQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/goodtables-ui/-/goodtables-ui-1.2.1.tgz",
+      "integrity": "sha512-yksAbtbbLFi9jhvTC5KUkqOUptuqnySxusikva7GW6r0AXYr4OEyfZFovb0hwj7HvB287zNib8BEhjn3jef9qA==",
       "requires": {
         "classnames": "2.2.5",
         "lodash": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "axios": "^0.15.3",
     "goodtables": "^0.7.2",
-    "goodtables-ui": "^1.2.0",
+    "goodtables-ui": "^1.2.1",
     "marked": "^0.3.6",
     "moment": "^2.18.1",
     "parts-selector": "github:smth/parts-selector",


### PR DESCRIPTION
@roll @amercader There was a bug when uploading a datapackage to https://try.goodtables.io. Part was on `goodtables-ui` (fixed on https://github.com/frictionlessdata/goodtables-ui/commit/002c889480e55d78d5dfcf367cfde12b84e28b52), and other part here.

Here, the problem was that we were only validating sources with `preset == 'table'`. I changed to validate both `table` and `datapackage`, but I'm wondering what was the reason to validate only table presets. I imagine this is because a data package with local files won't be validated (or would cause some potential security issue)?