### PR TITLE
Fix data type of amount field in writing_data_schema.md

### DIFF
--- a/docs/getting_started/writing_data_schema.md
+++ b/docs/getting_started/writing_data_schema.md
@@ -82,7 +82,7 @@ Writing this as a table schema in our data package, we have:
           },
           {
             "name": "amount",
-            "type": "numeric",
+            "type": "number",
             "description": "Transaction value in Euros",
             "constraints": {
               "minimum": 0


### PR DESCRIPTION
While going through the getting started docs, we copied the schema provided and were getting the error 

```
Provided schema is not valid.

How it could be resolved:

    Update schema descriptor to be a valid descriptor
    If this error should be ignored disable schema checks in goodtables.yml.

The full list of error messages:

    Table Schema error: Descriptor validation error: {'constraints': {'minimum': 0}, 'name': 'amount', 'format': 'default', 'type': 'numeric', 'description': 'Transaction value in Euros'} is not valid under any of the given schemas at "fields/3" in descriptor and at "properties/fields/items/anyOf" in profile
```

After reviewing the Table Schema documentation it seems that the correct type is `number` rather than `numeric`. This updates the documentation so that validation succeeds for the example.
